### PR TITLE
fix(vm): fix issue where first arg was not _start

### DIFF
--- a/libs/as-sdk-integration-tests/assembly/index.ts
+++ b/libs/as-sdk-integration-tests/assembly/index.ts
@@ -1,5 +1,6 @@
 import { httpFetch, Process } from '../../as-sdk/assembly/index';
-const args = Process.args()[0];
+
+const args = Process.args().at(1);
 
 if (args === 'testHttpRejection') {
   testHttpRejection();
@@ -16,6 +17,8 @@ export function testHttpRejection(): void {
     const buffer = Uint8Array.wrap(msg);
 
     Process.exit_with_result(0, buffer);
+  } else {
+    Process.exit_with_message(1, "Test failed");
   }
 }
 
@@ -28,6 +31,8 @@ export function testHttpSuccess(): void {
     const buffer = Uint8Array.wrap(msg);
 
     Process.exit_with_result(0, buffer);
+  } else {
+    Process.exit_with_message(31, 'My custom test failed');
   }
 }
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The first argument on the rust VM is _start but we've never included that in the SDK. In order to make them the same we should prepend _start as the first argumnet

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* Modifiy args to include _start as the first arg
* Modified the test to use Process.args()[1] instead of [0]

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

`npm test` 

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

closes #26 
