### PR TITLE
feat(vm): add tally vm adapter

### DIFF
--- a/libs/as-sdk-integration-tests/assembly/index.ts
+++ b/libs/as-sdk-integration-tests/assembly/index.ts
@@ -1,4 +1,5 @@
 import { httpFetch, Process } from '../../as-sdk/assembly/index';
+import { testTallyVmHttp, testTallyVmMode } from './vm-tests';
 
 const args = Process.args().at(1);
 
@@ -6,6 +7,10 @@ if (args === 'testHttpRejection') {
   testHttpRejection();
 } else if (args === 'testHttpSuccess') {
   testHttpSuccess();
+} else if (args === 'testTallyVmMode') {
+  testTallyVmMode();
+} else if (args === 'testTallyVmHttp') {
+  testTallyVmHttp();
 }
 
 export function testHttpRejection(): void {
@@ -18,7 +23,7 @@ export function testHttpRejection(): void {
 
     Process.exit_with_result(0, buffer);
   } else {
-    Process.exit_with_message(1, "Test failed");
+    Process.exit_with_message(1, 'Test failed');
   }
 }
 
@@ -35,5 +40,3 @@ export function testHttpSuccess(): void {
     Process.exit_with_message(31, 'My custom test failed');
   }
 }
-
-

--- a/libs/as-sdk-integration-tests/assembly/vm-tests.ts
+++ b/libs/as-sdk-integration-tests/assembly/vm-tests.ts
@@ -1,0 +1,28 @@
+import { Process, httpFetch } from '../../as-sdk/assembly/index';
+
+export function testTallyVmMode(): void {
+  const envs = Process.envs();
+  const vmMode = envs.get('VM_MODE');
+
+  if (vmMode === 'tally') {
+    Process.exit_with_message(0, 'tally');
+  } else {
+    Process.exit_with_message(1, 'dr');
+  }
+}
+
+export function testTallyVmHttp(): void {
+  const response = httpFetch('https://swapi.dev/api/planets/1/');
+  const fulfilled = response.fulfilled;
+  const rejected = response.rejected;
+
+  if (fulfilled !== null) {
+    Process.exit_with_message(1, 'this should not be allowed in tally mode');
+  }
+
+  if (rejected !== null) {
+    Process.exit_with_result(0, rejected.bytes);
+  }
+}
+
+

--- a/libs/as-sdk-integration-tests/src/http.test.ts
+++ b/libs/as-sdk-integration-tests/src/http.test.ts
@@ -10,6 +10,7 @@ jest.setTimeout(15_000);
 
 const TestVmAdapter = jest.fn().mockImplementation(() => {
   return {
+    modifyVmCallData: (v) => v,
     setProcessId: () => {},
     httpFetch: mockHttpFetch
   };

--- a/libs/as-sdk-integration-tests/src/tallyvm.test.ts
+++ b/libs/as-sdk-integration-tests/src/tallyvm.test.ts
@@ -1,0 +1,40 @@
+import { TallyVmAdapter, callVm } from '../../../dist/libs/vm';
+import { readFile } from 'node:fs/promises';
+
+describe('TallyVm', () => {
+  it('should run in tally vm mode', async () => {
+    const wasmBinary = await readFile(
+      'dist/libs/as-sdk-integration-tests/debug.wasm'
+    );
+    const result = await callVm(
+      {
+        args: ['testTallyVmMode'],
+        envs: {},
+        binary: new Uint8Array(wasmBinary),
+      },
+      undefined,
+      new TallyVmAdapter()
+    );
+
+    expect(result.resultAsString).toEqual('tally');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('should fail to make an http call', async () => {
+    const wasmBinary = await readFile(
+      'dist/libs/as-sdk-integration-tests/debug.wasm'
+    );
+    const result = await callVm(
+      {
+        args: ['testTallyVmHttp'],
+        envs: {},
+        binary: new Uint8Array(wasmBinary),
+      },
+      undefined,
+      new TallyVmAdapter()
+    );
+
+    expect(result.resultAsString).toEqual('http_fetch is not allowed in tally');
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/libs/as-sdk/assembly/process.ts
+++ b/libs/as-sdk/assembly/process.ts
@@ -1,4 +1,4 @@
-import { Process as WasiProcess, CommandLine } from 'as-wasi/assembly';
+import { Process as WasiProcess, CommandLine, Environ } from 'as-wasi/assembly';
 import { execution_result } from './bindings/seda_v1';
 
 export default class Process {
@@ -15,6 +15,28 @@ export default class Process {
    */
   static args(): string[] {
     return CommandLine.all;
+  }
+
+  /**
+   * Gets all the environment variables as a Map
+   *
+   * @returns {Map<string, string>} key, value pair with all environment variables
+   * @example
+   * ```ts
+   * const env = Process.env();
+   *
+   * const vmMode = env.get('VM_MODE');
+   * ```
+   */
+  static envs(): Map<string, string> {
+    const result: Map<string, string> = new Map();
+
+    for (let i: i32 = 0; i < Environ.all.length; i++) {
+      const entry = Environ.all[i];
+      result.set(entry.key, entry.value);
+    }
+
+    return result;
   }
 
   /**

--- a/libs/vm/src/data-request-vm-adapter.ts
+++ b/libs/vm/src/data-request-vm-adapter.ts
@@ -1,11 +1,22 @@
-import type { HttpFetchAction } from './types/vm-actions';
+import type { HttpFetchAction } from './types/vm-actions.js';
 import { HttpFetchResponse } from './types/vm-actions.js';
-import type { VmAdapter } from './types/vm-adapter';
+import type { VmAdapter } from './types/vm-adapter.js';
 import fetch from 'node-fetch';
 import { PromiseStatus } from './types/vm-promise.js';
+import { VmCallData } from './vm.js';
 
-export default class DefaultVmAdapter implements VmAdapter {
+export default class DataRequestVmAdapter implements VmAdapter {
   private processId?: string;
+
+  modifyVmCallData(input: VmCallData): VmCallData {
+    return {
+      ...input,
+      envs: {
+        ...input.envs,
+        VM_MODE: 'dr',
+      },
+    };
+  }
 
   setProcessId(processId: string) {
       this.processId = processId;

--- a/libs/vm/src/tally-vm-adapter.ts
+++ b/libs/vm/src/tally-vm-adapter.ts
@@ -1,0 +1,40 @@
+import type { HttpFetchAction } from './types/vm-actions';
+import { HttpFetchResponse } from './types/vm-actions.js';
+import type { VmAdapter } from './types/vm-adapter';
+import { PromiseStatus } from './types/vm-promise.js';
+import type { VmCallData } from './vm';
+
+export default class TallyVmAdapter implements VmAdapter {
+  private processId?: string;
+
+  modifyVmCallData(input: VmCallData): VmCallData {
+    return {
+      ...input,
+      envs: {
+        ...input.envs,
+        VM_MODE: 'tally'
+      }
+    };
+  }
+
+  setProcessId(processId: string) {
+    this.processId = processId;
+  }
+
+  async httpFetch(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _action: HttpFetchAction
+  ): Promise<PromiseStatus<HttpFetchResponse>> {
+    const error = new TextEncoder().encode('http_fetch is not allowed in tally');
+
+    return PromiseStatus.rejected(
+      new HttpFetchResponse({
+        bytes: Array.from(error),
+        content_length: error.length,
+        headers: {},
+        status: 0,
+        url: '',
+      })
+    );
+  }
+}

--- a/libs/vm/src/types/vm-adapter.ts
+++ b/libs/vm/src/types/vm-adapter.ts
@@ -1,8 +1,28 @@
+import type { VmCallData } from "../vm";
 import type { HttpFetchAction, HttpFetchResponse } from "./vm-actions";
 import { PromiseStatus } from "./vm-promise.js";
 
 
 export interface VmAdapter {
+  /**
+   * Allows the adapter to modify the call data before executing
+   * this can be used to inject arguments, environment variables, etc.
+   *
+   * @param input
+   */
+  modifyVmCallData(input: VmCallData): VmCallData;
+
+  /**
+   * Sets the process id in order to identify a vm call in the logs
+   *
+   * @param processId
+   */
   setProcessId(processId: string): void,
+
+  /**
+   * Method to do a remote http fetch call
+   *
+   * @param action
+   */
   httpFetch(action: HttpFetchAction): Promise<PromiseStatus<HttpFetchResponse>>;
 }

--- a/libs/vm/src/vm.ts
+++ b/libs/vm/src/vm.ts
@@ -16,7 +16,6 @@ export interface VmResult {
 }
 
 export async function executeVm(callData: VmCallData, notifierBuffer: SharedArrayBuffer, processId: string): Promise<VmResult> {
-
   await init();
   const wasi = new WASI({
     args: callData.args,


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Add tally vm mode which disallows http_fetch calls. This is required so that the user can test their tally binaries in the SDK.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* Add new Tally VM Adapter
* Add new environment variables which is either tally or dr so the user can detect what vm mode it is in

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Wrote a test for:
* http_fetch not available in tally mode
* making sure tally mode is activated

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

closes #24 
created:
* https://github.com/sedaprotocol/seda-overlay/issues/129
* https://github.com/sedaprotocol/seda-wasm-vm/issues/2
