### PR TITLE
feat(dev-tools): add getWasmBinary for CLI

### DIFF
--- a/libs/dev-tools/src/cli/utils/keccak256.ts
+++ b/libs/dev-tools/src/cli/utils/keccak256.ts
@@ -1,0 +1,5 @@
+import { keccak256 as hash } from "@cosmjs/crypto";
+
+export function keccak256(input: Uint8Array): string {
+    return Buffer.from(hash(input)).toString('hex');
+}

--- a/libs/dev-tools/src/index.ts
+++ b/libs/dev-tools/src/index.ts
@@ -2,6 +2,7 @@ export { buildSigningConfig } from '@dev-tools/services/config';
 export { Signer, type ISigner } from '@dev-tools/services/signer';
 
 export { uploadWasmBinary } from '@dev-tools/services/wasm/upload-wasm-binary';
+export { getWasmBinary } from '@dev-tools/services/wasm/get-wasm-binary';
 
 export { postDataRequest } from '@dev-tools/services/dr/post-data-request';
 export { getDataRequestStatus } from '@dev-tools/services/dr/get-data-request-status';

--- a/libs/dev-tools/src/lib/services/wasm/get-wasm-binary.ts
+++ b/libs/dev-tools/src/lib/services/wasm/get-wasm-binary.ts
@@ -1,0 +1,25 @@
+import { tryAsync } from "@dev-tools/utils/try-async";
+import { ISigner } from "../signer";
+import { createWasmQueryClient } from "./query-client";
+import { Maybe, Result } from "true-myth";
+import { Wasm } from "gen/index.sedachain.wasm_storage.v1";
+
+export async function getWasmBinary(signer: ISigner, id: string): Promise<Result<Maybe<Wasm>, string>> {
+    const queryClient = await tryAsync(async () => await createWasmQueryClient({
+        rpc: signer.getEndpoint(),
+    }));
+
+    if (queryClient.isErr) {
+        return Result.err(queryClient.error);
+    }
+
+    const binary = await tryAsync(async () => await queryClient.value.DataRequestWasm({
+        hash: id,
+    }));
+
+    if (binary.isErr) {
+        return Result.err(binary.error);
+    }
+
+    return Result.ok(Maybe.of(binary.value.wasm));
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Checks if an WASM binary exists before uploading. This helps saves costs.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* Create new method getWasmBinary
* Check when uploading if the binary exists and if so return it

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Run the upload command multiple times and you'll get the binary hash without uploading on chain

Closes #61 
