### PR TITLE
Correctly serialise request bodies

### DIFF
--- a/libs/as-sdk-integration-tests/assembly/http.ts
+++ b/libs/as-sdk-integration-tests/assembly/http.ts
@@ -35,3 +35,30 @@ export class TestHttpSuccess extends OracleProgram {
     Process.error(Bytes.fromString('Something went wrong..'), 20);
   }
 }
+
+export class TestPostHttpSuccess extends OracleProgram {
+  execution(): void {
+    const headers = new Map<string, string>();
+    headers.set('content-type', 'application/json');
+
+    const response = httpFetch('https://jsonplaceholder.typicode.com/posts', {
+      body: Bytes.fromString(
+        `{"title":"Test SDK","body":"Don't forget to test some integrations."}`
+      ),
+      method: 'POST',
+      headers,
+    });
+    const fulfilled = response.fulfilled;
+    const rejected = response.rejected;
+
+    if (fulfilled !== null) {
+      Process.success(fulfilled.bytes);
+    }
+
+    if (rejected !== null) {
+      Process.error(rejected.bytes);
+    }
+
+    Process.error(Bytes.fromString('Something went wrong..'), 20);
+  }
+}

--- a/libs/as-sdk-integration-tests/assembly/index.ts
+++ b/libs/as-sdk-integration-tests/assembly/index.ts
@@ -1,5 +1,5 @@
 import { Process, Bytes } from '../../as-sdk/assembly/index';
-import { TestHttpRejection, TestHttpSuccess } from './http';
+import { TestHttpRejection, TestHttpSuccess, TestPostHttpSuccess} from './http';
 import { testProxyHttpFetch } from './proxy-http';
 import { TestTallyVmReveals, TestTallyVmRevealsFiltered } from './tally';
 import { TestTallyVmHttp, TestTallyVmMode } from './vm-tests';
@@ -10,6 +10,8 @@ if (args === 'testHttpRejection') {
   new TestHttpRejection().run();
 } else if (args === 'testHttpSuccess') {
   new TestHttpSuccess().run();
+} else if (args === 'testPostHttpSuccess') {
+  new TestPostHttpSuccess().run();
 } else if (args === 'testTallyVmMode') {
   new TestTallyVmMode().run();
 } else if (args === 'testTallyVmHttp') {

--- a/libs/as-sdk-integration-tests/src/http.test.ts
+++ b/libs/as-sdk-integration-tests/src/http.test.ts
@@ -48,7 +48,10 @@ describe('Http', () => {
     const wasmBinary = await readFile(
       'dist/libs/as-sdk-integration-tests/debug.wasm'
     );
-    const result = await executeDrWasm(wasmBinary, Buffer.from('testHttpSuccess'));
+    const result = await executeDrWasm(
+      wasmBinary,
+      Buffer.from('testHttpSuccess')
+    );
 
     expect(result.exitCode).toBe(0);
     expect(result.result).toEqual(
@@ -59,6 +62,32 @@ describe('Http', () => {
             id: 1,
             title: 'delectus aut autem',
             completed: false,
+          },
+          undefined,
+          2
+        )
+      )
+    );
+  });
+
+  // Possibly flakey as it relies on internet connectivity and an external service
+  it('Test SDK HTTP POST Success', async () => {
+    const wasmBinary = await readFile(
+      'dist/libs/as-sdk-integration-tests/debug.wasm'
+    );
+    const result = await executeDrWasm(
+      wasmBinary,
+      Buffer.from('testPostHttpSuccess')
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.result).toEqual(
+      new TextEncoder().encode(
+        JSON.stringify(
+          {
+            title: 'Test SDK',
+            body: "Don't forget to test some integrations.",
+            id: 101,
           },
           undefined,
           2

--- a/libs/as-sdk/assembly/json-utils.ts
+++ b/libs/as-sdk/assembly/json-utils.ts
@@ -1,3 +1,5 @@
+import { Bytes } from "./bytes";
+
 export function jsonArrToUint8Array(array: u8[]): Uint8Array {
   const result = new Uint8Array(array.length);
   result.set(array);
@@ -5,11 +7,15 @@ export function jsonArrToUint8Array(array: u8[]): Uint8Array {
   return result;
 }
 
-export function uint8arrayToJsonArray(input: Uint8Array): u8[] {
+export function bytesToJsonArray(input: Bytes | null): u8[] {
   const result: u8[] = [];
 
-  for (let i = 0; i < input.length; i++) {
-    result.push(input[i]);
+  if (input === null) {
+    return result;
+  }
+
+  for (let i = 0; i < input.value.length; i++) {
+    result.push(input.value[i]);
   }
 
   return result;

--- a/libs/as-sdk/assembly/proxy-http.ts
+++ b/libs/as-sdk/assembly/proxy-http.ts
@@ -1,26 +1,29 @@
 import { JSON } from 'json-as/assembly';
-import { HttpFetchOptions, HttpFetch, HttpResponse } from "./http";
+import { HttpFetchOptions, HttpFetchAction, HttpResponse } from './http';
 import { call_result_write, proxy_http_fetch } from './bindings/seda_v1';
 import { PromiseStatus } from './promise';
 
-export function proxyHttpFetch(url: string, options: HttpFetchOptions = new HttpFetchOptions()): PromiseStatus<HttpResponse, HttpResponse> {
-    const action = new HttpFetch(url, options);
-    const actionStr = JSON.stringify(action);
+export function proxyHttpFetch(
+  url: string,
+  options: HttpFetchOptions = new HttpFetchOptions()
+): PromiseStatus<HttpResponse, HttpResponse> {
+  const action = new HttpFetchAction(url, options);
+  const actionStr = JSON.stringify(action);
 
-    const buffer = String.UTF8.encode(actionStr);
-    const utf8ptr = changetype<usize>(buffer);
+  const buffer = String.UTF8.encode(actionStr);
+  const utf8ptr = changetype<usize>(buffer);
 
-    const responseLength = proxy_http_fetch(utf8ptr, buffer.byteLength);
-    const responseBuffer = new ArrayBuffer(responseLength);
-    const responseBufferPtr = changetype<usize>(responseBuffer);
+  const responseLength = proxy_http_fetch(utf8ptr, buffer.byteLength);
+  const responseBuffer = new ArrayBuffer(responseLength);
+  const responseBufferPtr = changetype<usize>(responseBuffer);
 
-    call_result_write(responseBufferPtr, responseLength);
+  call_result_write(responseBufferPtr, responseLength);
 
-    const response = String.UTF8.decode(responseBuffer);
+  const response = String.UTF8.decode(responseBuffer);
 
-    return PromiseStatus.fromStr(
-        response,
-        new HttpResponse(),
-        new HttpResponse(),
-    );
+  return PromiseStatus.fromStr(
+    response,
+    new HttpResponse(),
+    new HttpResponse()
+  );
 }


### PR DESCRIPTION
## Motivation

Allow users to make Oracle Programs that utilise POST bodies.

## Explanation of Changes

The Uint8Array/Bytes we used previously were not correctly serialised when moving from the VM to the host. By converting them to a simple `u8[]` we also mimick the way back more closely.

## Testing

Added a test case which failed initially.

## Related PRs and Issues

Closes: #72
