### PR TITLE
ref(tally): use Bytes instead of u8 for the RevealResult

### DIFF
--- a/libs/as-sdk-integration-tests/src/tallyvm.test.ts
+++ b/libs/as-sdk-integration-tests/src/tallyvm.test.ts
@@ -106,7 +106,7 @@ describe('TallyVm', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.resultAsString).toBe(
-      '[{"salt":[115,101,100,97,95,115,100,107],"exit_code":0,"gas_used":"200000","reveal":[123,34,100,97,116,97,34,58,34,98,97,98,121,95,115,104,97,114,107,34,125],"in_consensus":0},{"salt":[115,101,100,97,95,115,100,107],"exit_code":1,"gas_used":"1336","reveal":[123,34,100,97,116,97,34,58,34,103,114,97,110,100,112,97,95,115,104,97,114,107,34,125],"in_consensus":0}]'
+      '[{\"salt\":{\"type\":\"hex\",\"value\":\"736564615f73646b\"},\"exit_code\":0,\"gas_used\":\"200000\",\"reveal\":{\"type\":\"hex\",\"value\":\"7b2264617461223a22626162795f736861726b227d\"},\"in_consensus\":0},{\"salt\":{\"type\":\"hex\",\"value\":\"736564615f73646b\"},\"exit_code\":1,\"gas_used\":\"1336\",\"reveal\":{\"type\":\"hex\",\"value\":\"7b2264617461223a226772616e6470615f736861726b227d\"},\"in_consensus\":0}]'
     );
   });
 
@@ -141,7 +141,7 @@ describe('TallyVm', () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.resultAsString).toBe(
-      '[{"salt":[115,101,100,97,95,115,100,107],"exit_code":0,"gas_used":"1336","reveal":[123,34,100,97,116,97,34,58,34,103,114,97,110,100,112,97,95,115,104,97,114,107,34,125],"in_consensus":0},{"salt":[115,101,100,97,95,115,100,107],"exit_code":0,"gas_used":"1346","reveal":[123,34,100,97,116,97,34,58,34,99,111,117,115,105,110,95,115,104,97,114,107,34,125],"in_consensus":0}]'
+      '[{\"salt\":{\"type\":\"hex\",\"value\":\"736564615f73646b\"},\"exit_code\":0,\"gas_used\":\"1336\",\"reveal\":{\"type\":\"hex\",\"value\":\"7b2264617461223a226772616e6470615f736861726b227d\"},\"in_consensus\":0},{\"salt\":{\"type\":\"hex\",\"value\":\"736564615f73646b\"},\"exit_code\":0,\"gas_used\":\"1346\",\"reveal\":{\"type\":\"hex\",\"value\":\"7b2264617461223a22636f7573696e5f736861726b227d\"},\"in_consensus\":0}]'
     );
   });
 });

--- a/libs/as-sdk/assembly/tally.ts
+++ b/libs/as-sdk/assembly/tally.ts
@@ -1,5 +1,7 @@
 import { JSON } from "json-as/assembly";
 import Process from "./process";
+import { Bytes } from "./bytes";
+import { jsonArrToUint8Array } from "./json-utils";
 
 const REVEALS_ARGUMENT_POSITION = 2;
 const CONSENSUS_ARGUMENT_POSITION = 3;
@@ -14,10 +16,10 @@ export class RevealBody {
 
 @json
 export class RevealResult {
-  salt!: u8[];
+  salt!: Bytes;
   exit_code!: u8;
   gas_used!: string;
-  reveal!: u8[];
+  reveal!: Bytes;
   in_consensus!: u8;
 }
 
@@ -44,8 +46,8 @@ export default class Tally {
       revealResults.push({
         exit_code: reveal.exit_code,
         gas_used: reveal.gas_used,
-        reveal: reveal.reveal,
-        salt: reveal.salt,
+        reveal: Bytes.fromBytes(jsonArrToUint8Array(reveal.reveal)),
+        salt: Bytes.fromBytes(jsonArrToUint8Array(reveal.salt)),
         in_consensus: consensus.at(index),
       });
     }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Makes it simpler to work with Reveals

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Convert `u8[]` to `Bytes` 

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

`bun run test` works after a modification in the expected result (Bytes returns a different shape then u8[])
