### PR TITLE
as-sdk: Correctly encode hex

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Check formatting
-        run: bun run fmt
+        run: bunx biome check .
 
       - name: Build projects
         run: bun run build

--- a/libs/as-sdk-integration-tests/assembly/hex.ts
+++ b/libs/as-sdk-integration-tests/assembly/hex.ts
@@ -1,0 +1,17 @@
+import {
+	Bytes,
+	OracleProgram,
+	Process,
+	encodeHex,
+} from "../../as-sdk/assembly";
+
+export class TestHexEncodeDecode extends OracleProgram {
+	execution(): void {
+		// Process.getInputs takes care of decoding the hex input
+		const rawBytes = Process.getInputs().value;
+
+		const hexString = encodeHex(rawBytes);
+
+		Process.success(Bytes.fromString(hexString));
+	}
+}

--- a/libs/as-sdk-integration-tests/assembly/index.ts
+++ b/libs/as-sdk-integration-tests/assembly/index.ts
@@ -1,5 +1,6 @@
 import { Bytes, Process } from "../../as-sdk/assembly/index";
 import { TestSecp256k1VerifyInvalid, TestSecp256k1VerifyValid } from "./crypto";
+import { TestHexEncodeDecode } from "./hex";
 import {
 	TestHttpRejection,
 	TestHttpSuccess,
@@ -31,6 +32,9 @@ if (args === "testHttpRejection") {
 	new TestSecp256k1VerifyValid().run();
 } else if (args === "testSecp256k1VerifyInvalid") {
 	new TestSecp256k1VerifyInvalid().run();
+	// Pretty iffy condition, not sure how else we can check for this though
+} else if (Process.getInputs().value.length === 26) {
+	new TestHexEncodeDecode().run();
 }
 
 Process.error(Bytes.fromString("No argument given"));

--- a/libs/as-sdk-integration-tests/src/hex.test.ts
+++ b/libs/as-sdk-integration-tests/src/hex.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { executeDrWasm } from "@seda/dev-tools";
+
+describe("hex", () => {
+	it("should encode hex to the same string that came in", async () => {
+		const wasmBinary = await readFile(
+			"dist/libs/as-sdk-integration-tests/debug.wasm",
+		);
+
+		const result = await executeDrWasm(
+			wasmBinary,
+			Buffer.from(
+				"000000000000c886c362e71402e05b3b6132b2e23832bcbc42f1",
+				"hex",
+			),
+		);
+
+		expect(result.resultAsString).toEqual(
+			"000000000000c886c362e71402e05b3b6132b2e23832bcbc42f1",
+		);
+	});
+});

--- a/libs/as-sdk/assembly/hex.ts
+++ b/libs/as-sdk/assembly/hex.ts
@@ -2,7 +2,7 @@ export function encodeHex(array: Uint8Array): string {
 	let hex = "";
 
 	for (let i = 0; i < array.length; i++) {
-		hex += array[i].toString(16);
+		hex += array[i].toString(16).padStart(2, "0");
 	}
 
 	return hex;

--- a/libs/as-sdk/assembly/process.ts
+++ b/libs/as-sdk/assembly/process.ts
@@ -58,7 +58,7 @@ export default class Process {
 	 * ```
 	 */
 	static getInputs(): Bytes {
-		// Data at index 0 is the dr/tally inputs encoded as hex
+		// Data at index 1 is the dr/tally inputs encoded as hex
 		const data = Process.args().at(1);
 
 		return Bytes.fromBytes(decodeHex(data));


### PR DESCRIPTION
## Motivation

Fix issues we were having converting to and from hex.

## Explanation of Changes

For values that took up less than 2 characters when encoded the old implementation did not correctly pad with zero.

## Testing

Added unit test that failed before implementing the fix.

## Related PRs and Issues

N.A.
