### PR TITLE
feat(sdk): add ability to set a expected public key on proxy calls

### DIFF
--- a/libs/as-sdk/assembly/bindings/seda_v1.ts
+++ b/libs/as-sdk/assembly/bindings/seda_v1.ts
@@ -17,7 +17,7 @@ export declare function execution_result(
 
 export declare function secp256k1_verify(
 	message: usize,
-	message_length: u32,
+	message_length: u64,
 	signature: usize,
 	signature_length: u32,
 	public_key: usize,

--- a/libs/as-sdk/assembly/http.ts
+++ b/libs/as-sdk/assembly/http.ts
@@ -123,7 +123,7 @@ export class HttpFetchOptions {
 }
 
 @json
-class SerializableHttpFetchOptions {
+export class SerializableHttpFetchOptions {
 	method!: string;
 	headers!: Map<string, string>;
 	body: u8[] = [];

--- a/libs/as-sdk/assembly/proxy-http.ts
+++ b/libs/as-sdk/assembly/proxy-http.ts
@@ -1,13 +1,39 @@
 import { JSON } from "json-as/assembly";
 import { call_result_write, proxy_http_fetch } from "./bindings/seda_v1";
 import { HttpFetchAction, HttpFetchOptions, HttpResponse } from "./http";
+// Is used in the transform (because ProxyHttpFetchAction extends from HttpFetchAction)
+import { SerializableHttpFetchOptions } from "./http";
 import { PromiseStatus } from "./promise";
 
+@json
+export class ProxyHttpFetchAction extends HttpFetchAction {
+	@omitnull()
+	public_key: string | null = null;
+
+	constructor(
+		url: string,
+		publicKey: string | null,
+		options: HttpFetchOptions,
+	) {
+		super(url, options);
+		this.public_key = publicKey;
+	}
+}
+
+/**
+ * Calls a Data Proxy Node the same way httpFetch does, but checks the signature and
+ *
+ * @param url The URL of the Data Proxy Node you want to access
+ * @param publicKey Optional: The public key of the proxy node, verifies if the signature came from this public key
+ * @param options Optional: Allows you to set headers, method, body
+ * @returns Promise with information about the response
+ */
 export function proxyHttpFetch(
 	url: string,
+	publicKey: string | null = null,
 	options: HttpFetchOptions = new HttpFetchOptions(),
 ): PromiseStatus<HttpResponse, HttpResponse> {
-	const action = new HttpFetchAction(url, options);
+	const action = new ProxyHttpFetchAction(url, publicKey, options);
 	const actionStr = JSON.stringify(action);
 
 	const buffer = String.UTF8.encode(actionStr);

--- a/libs/vm/src/vm-imports.ts
+++ b/libs/vm/src/vm-imports.ts
@@ -118,7 +118,7 @@ export default class VmImports {
 
 	secp256k1Verify(
 		messagePtr: number,
-		messageLength: number,
+		messageLength: bigint,
 		signaturePtr: number,
 		signatureLength: number,
 		publicKeyPtr: number,
@@ -126,7 +126,10 @@ export default class VmImports {
 	) {
 		const message = Buffer.from(
 			new Uint8Array(
-				this.memory?.buffer.slice(messagePtr, messagePtr + messageLength) ?? [],
+				this.memory?.buffer.slice(
+					messagePtr,
+					messagePtr + Number(messageLength),
+				) ?? [],
 			),
 		);
 		const signature = Buffer.from(


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Allows users to set an expected public key, when calling the proxy. 

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

* Add extra parameter to set a public key