### PR TITLE
More SDK improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,9 @@ class PlanetProgram extends OracleProgram {
     // HTTP Fetch to the SWAPI
     const response = httpFetch(`https://swapi.dev/api/planets/${input}`);
 
-    if (response.isFulfilled()) {
-      // We need to unwrap the response Bytes and convert them to a string before we can parse it as JSON.
-      const data = response.unwrap().toUtf8String();
-
-      // Parses the JSON string into the structured object we defined.
-      const planet = JSON.parse<SwPlanet>(data);
+    if (response.ok) {
+      // We need to parse the response Bytes as the expected JSON.
+      const planet = response.bytes.toJSON<SwPlanet>();
 
       // Exits the program (with an exit code of 0) and sets the Data Request result to the planet name
       Process.success(Bytes.fromUtf8String(planet.name));

--- a/libs/as-sdk-integration-tests/assembly/bytes.ts
+++ b/libs/as-sdk-integration-tests/assembly/bytes.ts
@@ -31,3 +31,38 @@ export class TestBytesSliceStartEnd extends OracleProgram {
 		Process.success(copy);
 	}
 }
+
+@json
+class NestedItem {
+	id!: i64;
+	value!: string;
+}
+@json
+class Test {
+	id!: i64;
+	value!: string;
+	important!: boolean;
+	list!: string[];
+	nested!: NestedItem;
+}
+@json
+class Output {
+	id!: i64;
+	firstList!: string;
+	nestedValue!: string;
+}
+
+export class TestBytesJSON extends OracleProgram {
+	execution(): void {
+		const input = Process.getInputs();
+
+		// Input starts with "testBytesJSON:"
+		const data = input.slice(14).toJSON<Test>();
+		const output = new Output();
+		output.id = data.id;
+		output.firstList = data.list.at(0);
+		output.nestedValue = data.nested.value;
+
+		Process.success(Bytes.fromJSON(output));
+	}
+}

--- a/libs/as-sdk-integration-tests/assembly/http.ts
+++ b/libs/as-sdk-integration-tests/assembly/http.ts
@@ -17,12 +17,25 @@ export class TestHttpRejection extends OracleProgram {
 	}
 }
 
+@json
+class TodoResponse {
+	userId!: i64;
+	id!: i64;
+	title!: string;
+	completed!: boolean;
+}
+
 export class TestHttpSuccess extends OracleProgram {
 	execution(): void {
 		const response = httpFetch("https://jsonplaceholder.typicode.com/todos/1");
 
 		if (response.isFulfilled()) {
-			Process.success(response.unwrap().bytes);
+			const data = response.unwrap().bytes.toJSON<TodoResponse>();
+			Process.success(
+				Bytes.fromUtf8String(
+					`${data.userId}:${data.id}:${data.title}:${data.completed}`,
+				),
+			);
 		}
 
 		if (response.isRejected()) {
@@ -31,6 +44,13 @@ export class TestHttpSuccess extends OracleProgram {
 
 		Process.error(Bytes.fromUtf8String("Something went wrong.."), 20);
 	}
+}
+
+@json
+class PostResponse {
+	title!: string;
+	body!: string;
+	id!: i64;
 }
 
 export class TestPostHttpSuccess extends OracleProgram {
@@ -47,7 +67,10 @@ export class TestPostHttpSuccess extends OracleProgram {
 		});
 
 		if (response.isFulfilled()) {
-			Process.success(response.unwrap().bytes);
+			const data = response.unwrap().bytes.toJSON<PostResponse>();
+			Process.success(
+				Bytes.fromUtf8String(`${data.id}:${data.title}:${data.body}`),
+			);
 		}
 
 		if (response.isRejected()) {

--- a/libs/as-sdk-integration-tests/assembly/http.ts
+++ b/libs/as-sdk-integration-tests/assembly/http.ts
@@ -9,7 +9,7 @@ export class TestHttpRejection extends OracleProgram {
 	execution(): void {
 		const response = httpFetch("example.com/");
 
-		if (response.isRejected()) {
+		if (!response.ok) {
 			Process.success(Bytes.fromUtf8String("rejected"));
 		} else {
 			Process.error(Bytes.fromUtf8String("Test failed"));
@@ -29,8 +29,8 @@ export class TestHttpSuccess extends OracleProgram {
 	execution(): void {
 		const response = httpFetch("https://jsonplaceholder.typicode.com/todos/1");
 
-		if (response.isFulfilled()) {
-			const data = response.unwrap().bytes.toJSON<TodoResponse>();
+		if (response.ok) {
+			const data = response.bytes.toJSON<TodoResponse>();
 			Process.success(
 				Bytes.fromUtf8String(
 					`${data.userId}:${data.id}:${data.title}:${data.completed}`,
@@ -38,11 +38,7 @@ export class TestHttpSuccess extends OracleProgram {
 			);
 		}
 
-		if (response.isRejected()) {
-			Process.error(response.unwrapRejected().bytes);
-		}
-
-		Process.error(Bytes.fromUtf8String("Something went wrong.."), 20);
+		Process.error(response.bytes);
 	}
 }
 
@@ -66,17 +62,13 @@ export class TestPostHttpSuccess extends OracleProgram {
 			headers,
 		});
 
-		if (response.isFulfilled()) {
-			const data = response.unwrap().bytes.toJSON<PostResponse>();
+		if (response.ok) {
+			const data = response.bytes.toJSON<PostResponse>();
 			Process.success(
 				Bytes.fromUtf8String(`${data.id}:${data.title}:${data.body}`),
 			);
 		}
 
-		if (response.isRejected()) {
-			Process.error(response.unwrap().bytes);
-		}
-
-		Process.error(Bytes.fromUtf8String("Something went wrong.."), 20);
+		Process.error(response.bytes);
 	}
 }

--- a/libs/as-sdk-integration-tests/assembly/index.ts
+++ b/libs/as-sdk-integration-tests/assembly/index.ts
@@ -56,7 +56,7 @@ if (args === "testHttpRejection") {
 } else if (args === "testBytesHexEncodeDecode") {
 	new TestBytesHexEncodeDecode().run();
 } else if (args === "testBytesPrefixedHexDecode") {
-	new TestBytesHexEncodeDecode().run();
+	new TestBytesPrefixedHexDecode().run();
 } else if (args.startsWith("testBytesJSON")) {
 	new TestBytesJSON().run();
 	// Pretty iffy condition, not sure how else we can check for this though

--- a/libs/as-sdk-integration-tests/assembly/index.ts
+++ b/libs/as-sdk-integration-tests/assembly/index.ts
@@ -1,5 +1,6 @@
 import { Bytes, Process } from "../../as-sdk/assembly/index";
 import {
+	TestBytesJSON,
 	TestBytesSliceNoArguments,
 	TestBytesSliceOnlyStart,
 	TestBytesSliceStartEnd,
@@ -55,7 +56,9 @@ if (args === "testHttpRejection") {
 } else if (args === "testBytesHexEncodeDecode") {
 	new TestBytesHexEncodeDecode().run();
 } else if (args === "testBytesPrefixedHexDecode") {
-	new TestBytesPrefixedHexDecode().run();
+	new TestBytesHexEncodeDecode().run();
+} else if (args.startsWith("testBytesJSON")) {
+	new TestBytesJSON().run();
 	// Pretty iffy condition, not sure how else we can check for this though
 } else if (Process.getInputs().value.length === 26) {
 	new TestHexInputEncodeDecode().run();

--- a/libs/as-sdk-integration-tests/assembly/proxy-http.ts
+++ b/libs/as-sdk-integration-tests/assembly/proxy-http.ts
@@ -1,22 +1,13 @@
-import {
-	Bytes,
-	OracleProgram,
-	Process,
-	proxyHttpFetch,
-} from "../../as-sdk/assembly";
+import { OracleProgram, Process, proxyHttpFetch } from "../../as-sdk/assembly";
 
 export class TestProxyHttpFetch extends OracleProgram {
 	execution(): void {
 		const response = proxyHttpFetch("http://localhost:5384/proxy/planets/1");
 
-		if (response.isFulfilled()) {
-			Process.success(response.unwrap().bytes);
+		if (response.ok) {
+			Process.success(response.bytes);
 		}
 
-		if (response.isRejected()) {
-			Process.error(response.unwrapRejected().bytes);
-		}
-
-		Process.error(Bytes.fromUtf8String("Something went wrong.."), 20);
+		Process.error(response.bytes);
 	}
 }

--- a/libs/as-sdk-integration-tests/assembly/vm-tests.ts
+++ b/libs/as-sdk-integration-tests/assembly/vm-tests.ts
@@ -18,17 +18,13 @@ export class TestTallyVmMode extends OracleProgram {
 export class TestTallyVmHttp extends OracleProgram {
 	tally(): void {
 		const response = httpFetch("https://swapi.dev/api/planets/1/");
-		const fulfilled = response.fulfilled;
-		const rejected = response.rejected;
 
-		if (fulfilled !== null) {
+		if (response.ok) {
 			Process.error(
 				Bytes.fromUtf8String("this should not be allowed in tally mode"),
 			);
 		}
 
-		if (rejected !== null) {
-			Process.success(rejected.bytes);
-		}
+		Process.success(response.bytes);
 	}
 }

--- a/libs/as-sdk-integration-tests/src/bytes.test.ts
+++ b/libs/as-sdk-integration-tests/src/bytes.test.ts
@@ -38,4 +38,27 @@ describe("bytes", () => {
 			expect(result.resultAsString).toEqual("Slice");
 		});
 	});
+
+	describe("json", () => {
+		it("should be possible to parse Bytes as JSON and output Bytes as JSON", async () => {
+			const input = JSON.stringify({
+				id: 1,
+				value: "none",
+				important: false,
+				list: ["first", "second"],
+				nested: {
+					id: 999,
+					value: "some",
+				},
+			});
+			const result = await executeDrWasm(
+				wasmBinary,
+				Buffer.from(`testBytesJSON:${input}`),
+			);
+
+			expect(result.resultAsString).toEqual(
+				'{"id":1,"firstList":"first","nestedValue":"some"}',
+			);
+		});
+	});
 });

--- a/libs/as-sdk-integration-tests/src/http.test.ts
+++ b/libs/as-sdk-integration-tests/src/http.test.ts
@@ -22,7 +22,7 @@ describe("Http", () => {
 		);
 
 		expect(result.exitCode).toBe(0);
-		expect(result.result).toEqual(new TextEncoder().encode("rejected"));
+		expect(result.resultAsString).toEqual("rejected");
 	});
 
 	it("Test mocked SDK HTTP Success", async () => {
@@ -30,7 +30,14 @@ describe("Http", () => {
 			"dist/libs/as-sdk-integration-tests/debug.wasm",
 		);
 
-		const mockResponse = new Response("mock_ok", { statusText: "mock_ok" });
+		const mockResponse = new Response(
+			JSON.stringify({
+				userId: 200,
+				id: 999,
+				title: "mocked",
+				completed: true,
+			}),
+		);
 		mockHttpFetch.mockResolvedValue(mockResponse);
 
 		const result = await executeDrWasm(
@@ -40,7 +47,7 @@ describe("Http", () => {
 		);
 
 		expect(result.exitCode).toBe(0);
-		expect(result.result).toEqual(new TextEncoder().encode("mock_ok"));
+		expect(result.resultAsString).toEqual("200:999:mocked:true");
 	});
 
 	// Possibly flakey as it relies on internet connectivity and an external service
@@ -54,20 +61,7 @@ describe("Http", () => {
 		);
 
 		expect(result.exitCode).toBe(0);
-		expect(result.result).toEqual(
-			new TextEncoder().encode(
-				JSON.stringify(
-					{
-						userId: 1,
-						id: 1,
-						title: "delectus aut autem",
-						completed: false,
-					},
-					undefined,
-					2,
-				),
-			),
-		);
+		expect(result.resultAsString).toEqual("1:1:delectus aut autem:false");
 	});
 
 	// Possibly flakey as it relies on internet connectivity and an external service
@@ -81,18 +75,8 @@ describe("Http", () => {
 		);
 
 		expect(result.exitCode).toBe(0);
-		expect(result.result).toEqual(
-			new TextEncoder().encode(
-				JSON.stringify(
-					{
-						title: "Test SDK",
-						body: "Don't forget to test some integrations.",
-						id: 101,
-					},
-					undefined,
-					2,
-				),
-			),
+		expect(result.resultAsString).toEqual(
+			"101:Test SDK:Don't forget to test some integrations.",
 		);
 	});
 

--- a/libs/as-sdk/README.md
+++ b/libs/as-sdk/README.md
@@ -18,8 +18,8 @@ class PlanetProgram extends OracleProgram {
   execute(): void {
     const response = httpFetch("https://swapi.dev/api/planets/1/");
 
-    if (response.isFulfilled()) {
-      const planet = JSON.parse<SwPlanet>(response.unwrap().toUtf8String());
+    if (response.ok) {
+      const planet = response.bytes.toJSON<SwPlanet>();
 
       Console.log(planet);
 

--- a/libs/as-sdk/assembly/bytes.ts
+++ b/libs/as-sdk/assembly/bytes.ts
@@ -232,4 +232,51 @@ export class Bytes {
 		const byteSlice = this.value.slice(begin, end);
 		return new Bytes(byteSlice);
 	}
+
+	/**
+	 * Attempts to deserialize the Bytes into the '@json' annotated class `<T>`.
+	 * @example
+	 * ```ts
+		@json
+		class Data {
+			id!: i64;
+			value!: string;
+		}
+
+		const data = Bytes.fromString("{"id":1,"value":"test"}");
+
+		const responseData = data.toJSON<Data>();
+
+		Console.log(responseData.value); // "test"
+	 * ```
+	 * @returns an instance of '@json' annotated class <T>
+	 */
+	toJSON<T>(): T {
+		return JSON.parse<T>(this.toUtf8String());
+	}
+
+	/**
+	 * Serialises a '@json' annotated class (`<T>`) as a string and returns the Bytes representation
+	 * of that string.
+	 *
+	 * @example
+	 * ```ts
+		@json
+		class Data {
+			id!: i64;
+			value!: string;
+		}
+
+		const data = new Data();
+		data.id = 1;
+		data.value = "test";
+
+		Process.success(Bytes.fromJSON<Data>(data)); // Sets "{"id":1,"value":"test"}" in bytes as the result
+	 * ```
+	 * @param data an instance of the '@json' annotated class <T>
+	 */
+	static fromJSON<T>(data: T): Bytes {
+		const serialized = JSON.stringify<T>(data);
+		return Bytes.fromUtf8String(serialized);
+	}
 }

--- a/libs/as-sdk/assembly/http.ts
+++ b/libs/as-sdk/assembly/http.ts
@@ -46,6 +46,13 @@ export class HttpResponse implements FromBuffer<HttpResponse> {
 	 */
 	public headers: Map<string, string> = new Map();
 
+	/**
+	 * Convenience property representing if the request ended normally
+	 */
+	get ok(): boolean {
+		return this.status >= 200 && this.status < 300;
+	}
+
 	/** @hidden */
 	static fromSerializable(value: SerializableHttpResponse): HttpResponse {
 		const response = new HttpResponse();

--- a/libs/as-sdk/assembly/http.ts
+++ b/libs/as-sdk/assembly/http.ts
@@ -103,7 +103,7 @@ export class HttpResponse implements FromBuffer<HttpResponse> {
 /**
  * @hidden As it's not relevant for the generated documentation
  */
-export type HttpFetchMethod = "Get";
+export type HttpFetchMethod = string;
 
 /**
  * Request options to pass to {@linkcode httpFetch}.

--- a/libs/as-sdk/assembly/http.ts
+++ b/libs/as-sdk/assembly/http.ts
@@ -175,8 +175,8 @@ export class HttpFetchAction {
  * ```ts
  * const response = httpFetch("https://swapi.dev/api/planets/1/");
  *
- * if (response.isFulfilled()) {
- *   const data = response.unwrap().bytes.toUtf8String();
+ * if (response.ok) {
+ *   const data = response.bytes.toUtf8String();
  *   // Do something with data
  * } else {
  *   // Error occured
@@ -186,7 +186,7 @@ export class HttpFetchAction {
 export function httpFetch(
 	url: string,
 	options: HttpFetchOptions = new HttpFetchOptions(),
-): PromiseStatus<HttpResponse, HttpResponse> {
+): HttpResponse {
 	const action = new HttpFetchAction(url, options);
 	const actionStr = JSON.stringify(action);
 
@@ -201,9 +201,15 @@ export function httpFetch(
 
 	const response = String.UTF8.decode(responseBuffer);
 
-	return PromiseStatus.fromStr(
+	const promise = PromiseStatus.fromStr(
 		response,
 		new HttpResponse(),
 		new HttpResponse(),
 	);
+
+	if (promise.isFulfilled()) {
+		return promise.unwrap();
+	}
+
+	return promise.unwrapRejected();
 }

--- a/libs/as-sdk/assembly/promise.ts
+++ b/libs/as-sdk/assembly/promise.ts
@@ -94,4 +94,33 @@ export class PromiseStatus<F, R> {
 
 		return rejected;
 	}
+
+	/**
+	 * Execute a callback only if the promiseStatus was fulfilled.
+	 * @returns the PromiseStatus instance for method chaining
+	 */
+	// biome-ignore lint/suspicious/noThenProperty: we're emulating the Promises DX in AssemblyScript.
+	then(thenFn: (fulfilled: F) => void): PromiseStatus<F, R> {
+		const fulfilled = this.fulfilled;
+
+		if (fulfilled !== null) {
+			thenFn(fulfilled);
+		}
+
+		return this;
+	}
+
+	/**
+	 * Execute a callback only if the promiseStatus was rejected.
+	 * @returns the PromiseStatus instance for method chaining
+	 */
+	catch(catchFn: (rejected: R) => void): PromiseStatus<F, R> {
+		const rejected = this.rejected;
+
+		if (rejected !== null) {
+			catchFn(rejected);
+		}
+
+		return this;
+	}
 }

--- a/libs/as-sdk/assembly/proxy-http.ts
+++ b/libs/as-sdk/assembly/proxy-http.ts
@@ -29,12 +29,23 @@ export class ProxyHttpFetchAction extends HttpFetchAction {
  * @param publicKey Optional: The public key of the proxy node, verifies if the signature came from this public key
  * @param options Optional: Allows you to set headers, method, body
  * @returns Promise with information about the response
+ * @example
+ * ```ts
+ * const response = proxyHttpFetch("https://swapi.dev/api/planets/1/");
+ *
+ * if (response.ok) {
+ *   const data = response.bytes.toUtf8String();
+ *   // Do something with data
+ * } else {
+ *   // Error occured
+ * }
+ * ```
  */
 export function proxyHttpFetch(
 	url: string,
 	publicKey: string | null = null,
 	options: HttpFetchOptions = new HttpFetchOptions(),
-): PromiseStatus<HttpResponse, HttpResponse> {
+): HttpResponse {
 	const action = new ProxyHttpFetchAction(url, publicKey, options);
 	const actionStr = JSON.stringify(action);
 
@@ -49,9 +60,15 @@ export function proxyHttpFetch(
 
 	const response = String.UTF8.decode(responseBuffer);
 
-	return PromiseStatus.fromStr(
+	const promise = PromiseStatus.fromStr(
 		response,
 		new HttpResponse(),
 		new HttpResponse(),
 	);
+
+	if (promise.isFulfilled()) {
+		return promise.unwrap();
+	}
+
+	return promise.unwrapRejected();
 }

--- a/libs/as-sdk/package.json
+++ b/libs/as-sdk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/as-sdk",
 	"type": "module",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"types": "./assembly/index.ts",
 	"dependencies": {
 		"@assemblyscript/wasi-shim": "git+https://github.com/sedaprotocol/wasi-shim.git",


### PR DESCRIPTION
## Motivation

Make common usage patterns require less code.

## Explanation of Changes

Add a simple getter on the HttpResponse to quickly check whether the response status falls in the 200-299 inclusive range.

Also add some JSON convenience methods to `Bytes` to quickly (de)serialise so the user doesn't have to do the string conversion manually.

## Testing

Added and updated existing integration tests.

## Related PRs and Issues

N.A.