### PR TITLE
Allow importing execute functions from bundle

### DIFF
--- a/libs/as-sdk-integration-tests/project.json
+++ b/libs/as-sdk-integration-tests/project.json
@@ -18,9 +18,8 @@
 				"command": "bun test libs/as-sdk-integration-tests/"
 			},
 			"dependsOn": [
-				{
-					"target": "build"
-				}
+				{ "target": "build" },
+				{ "target": "build", "projects": ["dev-tools"] }
 			]
 		}
 	}

--- a/libs/dev-tools/build.ts
+++ b/libs/dev-tools/build.ts
@@ -4,5 +4,6 @@ await Bun.build({
 	entrypoints: ["./src/index.ts"],
 	target: "node",
 	outdir: "build",
+	external: ["@seda-protocol/vm"],
 	plugins: [dts()],
 });

--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"build": "nx run-many --all --target=build",
 		"cli": "bun run libs/dev-tools/bin/index.js",
 		"fmt": "bunx biome check --write .",
-		"test": "bun run build && NODE_OPTIONS=--experimental-vm-modules nx run-many --all --target=test",
+		"test": "nx run-many --all --target=test",
 		"docs": "bun run tools/typedoc/generate.ts",
 		"cli:generate": "cd libs/cli/proto && npx buf generate"
 	},


### PR DESCRIPTION
## Motivation

Fixes an issue where the user had to know the exact location of the source file to get a successful execution of the VM, but that caused TypeScript to complain.

## Explanation of Changes

Previously the compiled bundle caused problems when attempting to call executeDrWasm or executeTallyWasm, as it tried to resolve a path based on the location of the bundle, not the @seda-protocol/vm index file. By externalising the dependency it should now work correctly while retaining the type information.

## Testing

With `npm pack` and manually changing the `node_modules` of the request starter kit

## Related PRs and Issues

N.A.
