### PR TITLE
Signature verification

### DIFF
--- a/libs/as-sdk-integration-tests/assembly/bytes.ts
+++ b/libs/as-sdk-integration-tests/assembly/bytes.ts
@@ -32,6 +32,34 @@ export class TestBytesSliceStartEnd extends OracleProgram {
 	}
 }
 
+export class TestBytesConcat extends OracleProgram {
+	execution(): void {
+		const input = Process.getInputs();
+
+		// Input starts with "testBytesConcat:"
+		const data = input.slice(16);
+
+		const result = Bytes.fromUtf8String("Hello, ").concat(data);
+
+		Process.success(result);
+	}
+}
+
+export class TestBytesStaticConcat extends OracleProgram {
+	execution(): void {
+		const input = Process.getInputs();
+
+		// Input starts with "TestBytesStaticConcat:"
+		const start = input.slice(0, 21);
+		const middle = input.slice(21, 22);
+		const end = input.slice(22);
+
+		const result = Bytes.concat([end, middle, start]);
+
+		Process.success(result);
+	}
+}
+
 @json
 class NestedItem {
 	id!: i64;

--- a/libs/as-sdk-integration-tests/assembly/crypto.ts
+++ b/libs/as-sdk-integration-tests/assembly/crypto.ts
@@ -3,6 +3,7 @@ import {
 	OracleProgram,
 	Process,
 	decodeHex,
+	keccak256,
 	secp256k1Verify,
 } from "../../as-sdk/assembly";
 
@@ -49,5 +50,15 @@ export class TestSecp256k1VerifyInvalid extends OracleProgram {
 		} else {
 			Process.error(Bytes.fromUtf8String("invalid secp256k1 signature"));
 		}
+	}
+}
+
+export class TestKeccak256 extends OracleProgram {
+	execution(): void {
+		const message = Process.getInputs();
+
+		const result = keccak256(message);
+
+		Process.success(Bytes.fromUtf8String(result.toHexString()));
 	}
 }

--- a/libs/as-sdk-integration-tests/assembly/index.ts
+++ b/libs/as-sdk-integration-tests/assembly/index.ts
@@ -8,7 +8,11 @@ import {
 	TestBytesStaticConcat,
 } from "./bytes";
 import { TestLogBuffer, TestLogByteArray } from "./console";
-import { TestSecp256k1VerifyInvalid, TestSecp256k1VerifyValid } from "./crypto";
+import {
+	TestKeccak256,
+	TestSecp256k1VerifyInvalid,
+	TestSecp256k1VerifyValid,
+} from "./crypto";
 import {
 	TestBytesHexEncodeDecode,
 	TestBytesPrefixedHexDecode,
@@ -45,6 +49,8 @@ if (args === "testHttpRejection") {
 	new TestSecp256k1VerifyValid().run();
 } else if (args === "testSecp256k1VerifyInvalid") {
 	new TestSecp256k1VerifyInvalid().run();
+} else if (args === "testKeccak256") {
+	new TestKeccak256().run();
 } else if (args === "testLogBuffer") {
 	new TestLogBuffer().run();
 } else if (args === "testLogByteArray") {

--- a/libs/as-sdk-integration-tests/assembly/index.ts
+++ b/libs/as-sdk-integration-tests/assembly/index.ts
@@ -23,7 +23,7 @@ import {
 	TestHttpSuccess,
 	TestPostHttpSuccess,
 } from "./http";
-import { TestProxyHttpFetch } from "./proxy-http";
+import { TestGenerateProxyMessage, TestProxyHttpFetch } from "./proxy-http";
 import { TestTallyVmReveals, TestTallyVmRevealsFiltered } from "./tally";
 import { TestTallyVmHttp, TestTallyVmMode } from "./vm-tests";
 
@@ -45,6 +45,8 @@ if (args === "testHttpRejection") {
 	new TestTallyVmRevealsFiltered().run();
 } else if (args === "testProxyHttpFetch") {
 	new TestProxyHttpFetch().run();
+} else if (args === "testGenerateProxyMessage") {
+	new TestGenerateProxyMessage().run();
 } else if (args === "testSecp256k1VerifyValid") {
 	new TestSecp256k1VerifyValid().run();
 } else if (args === "testSecp256k1VerifyInvalid") {

--- a/libs/as-sdk-integration-tests/assembly/index.ts
+++ b/libs/as-sdk-integration-tests/assembly/index.ts
@@ -1,9 +1,11 @@
 import { Bytes, Process } from "../../as-sdk/assembly/index";
 import {
+	TestBytesConcat,
 	TestBytesJSON,
 	TestBytesSliceNoArguments,
 	TestBytesSliceOnlyStart,
 	TestBytesSliceStartEnd,
+	TestBytesStaticConcat,
 } from "./bytes";
 import { TestLogBuffer, TestLogByteArray } from "./console";
 import { TestSecp256k1VerifyInvalid, TestSecp256k1VerifyValid } from "./crypto";
@@ -53,6 +55,10 @@ if (args === "testHttpRejection") {
 	new TestBytesSliceOnlyStart().run();
 } else if (args === "testBytesSliceStartEnd") {
 	new TestBytesSliceStartEnd().run();
+} else if (args.startsWith("testBytesConcat")) {
+	new TestBytesConcat().run();
+} else if (args.startsWith("testBytesStaticConcat")) {
+	new TestBytesStaticConcat().run();
 } else if (args === "testBytesHexEncodeDecode") {
 	new TestBytesHexEncodeDecode().run();
 } else if (args === "testBytesPrefixedHexDecode") {

--- a/libs/as-sdk-integration-tests/assembly/proxy-http.ts
+++ b/libs/as-sdk-integration-tests/assembly/proxy-http.ts
@@ -1,4 +1,10 @@
-import { OracleProgram, Process, proxyHttpFetch } from "../../as-sdk/assembly";
+import {
+	Bytes,
+	OracleProgram,
+	Process,
+	generateProxyHttpSigningMessage,
+	proxyHttpFetch,
+} from "../../as-sdk/assembly";
 
 export class TestProxyHttpFetch extends OracleProgram {
 	execution(): void {
@@ -9,5 +15,18 @@ export class TestProxyHttpFetch extends OracleProgram {
 		}
 
 		Process.error(response.bytes);
+	}
+}
+
+export class TestGenerateProxyMessage extends OracleProgram {
+	execution(): void {
+		const message = generateProxyHttpSigningMessage(
+			"https://example.com",
+			"get",
+			Bytes.empty(),
+			Bytes.fromUtf8String(`{"name":"data-proxy"}`),
+		);
+
+		Process.success(Bytes.fromUtf8String(message.toHexString()));
 	}
 }

--- a/libs/as-sdk-integration-tests/src/bytes.test.ts
+++ b/libs/as-sdk-integration-tests/src/bytes.test.ts
@@ -7,6 +7,26 @@ const wasmBinary = await readFile(
 );
 
 describe("bytes", () => {
+	describe("concat", () => {
+		it("should concatenate 2 Bytes instances in a new one", async () => {
+			const result = await executeDrWasm(
+				wasmBinary,
+				Buffer.from("testBytesConcat:world!"),
+			);
+
+			expect(result.resultAsString).toBe("Hello, world!");
+		});
+
+		it("should allow passing an array of bytes to the static method and concatenate them", async () => {
+			const result = await executeDrWasm(
+				wasmBinary,
+				Buffer.from("testBytesStaticConcat:swap"),
+			);
+
+			expect(result.resultAsString).toBe("swap:testBytesStaticConcat");
+		});
+	});
+
 	describe("slice", () => {
 		it("should return a new bytes instance when called without arguments", async () => {
 			const result = await executeDrWasm(

--- a/libs/as-sdk-integration-tests/src/crypto.test.ts
+++ b/libs/as-sdk-integration-tests/src/crypto.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { executeDrWasm } from "@seda/dev-tools";
 
+const wasmBinary = await readFile(
+	"dist/libs/as-sdk-integration-tests/debug.wasm",
+);
+
 describe("Crypto", () => {
 	it("Test valid Secp256k1 signature", async () => {
-		const wasmBinary = await readFile(
-			"dist/libs/as-sdk-integration-tests/debug.wasm",
-		);
-
 		const result = await executeDrWasm(
 			wasmBinary,
 			Buffer.from("testSecp256k1VerifyValid"),
@@ -17,15 +17,24 @@ describe("Crypto", () => {
 	});
 
 	it("Test invalid Secp256k1 signature", async () => {
-		const wasmBinary = await readFile(
-			"dist/libs/as-sdk-integration-tests/debug.wasm",
-		);
-
 		const result = await executeDrWasm(
 			wasmBinary,
 			Buffer.from("testSecp256k1VerifyInvalid"),
 		);
 
 		expect(result.resultAsString).toEqual("invalid secp256k1 signature");
+	});
+
+	describe("keccak256", () => {
+		it("should hash the input bytes correctly", async () => {
+			const result = await executeDrWasm(
+				wasmBinary,
+				Buffer.from("testKeccak256"),
+			);
+
+			expect(result.resultAsString).toEqual(
+				"fe8baa653979909c621153b53c973bab3832768b5e77896a5b5944d20d48c7a6",
+			);
+		});
 	});
 });

--- a/libs/as-sdk-integration-tests/src/proxy-http.test.ts
+++ b/libs/as-sdk-integration-tests/src/proxy-http.test.ts
@@ -5,16 +5,16 @@ import { Response } from "node-fetch";
 
 const mockHttpFetch = mock();
 
+const wasmBinary = await readFile(
+	"dist/libs/as-sdk-integration-tests/debug.wasm",
+);
+
 describe("ProxyHttp", () => {
 	beforeEach(() => {
 		mockHttpFetch.mockReset();
 	});
 
 	it.skip("should allow proxy_http_fetch which have a valid signature", async () => {
-		const wasmBinary = await readFile(
-			"dist/libs/as-sdk-integration-tests/debug.wasm",
-		);
-
 		const mockResponse = new Response('"Tatooine"', {
 			headers: {
 				"x-seda-signature":
@@ -37,10 +37,6 @@ describe("ProxyHttp", () => {
 	});
 
 	it.skip("should reject if the proxy_http_fetch has an invalid signature", async () => {
-		const wasmBinary = await readFile(
-			"dist/libs/as-sdk-integration-tests/debug.wasm",
-		);
-
 		const mockResponse = new Response('"Tatooine"', {
 			statusText: "mock_ok",
 			headers: {
@@ -62,6 +58,19 @@ describe("ProxyHttp", () => {
 		expect(result.exitCode).toBe(1);
 		expect(result.result).toEqual(
 			new TextEncoder().encode("Invalid signature"),
+		);
+	});
+});
+
+describe("generateProxyHttpSigningMessage", () => {
+	it("should generate the expected message", async () => {
+		const result = await executeDrWasm(
+			wasmBinary,
+			Buffer.from("testGenerateProxyMessage"),
+		);
+
+		expect(result.resultAsString).toBe(
+			"edba3f8cfcd4165f73cd4641ced2b2ec0d3ba4338e3eec30edd58777d86b53b25a61babeb76c554783ca90a1a250e84f1b703409fdff33c217ab64dd51f05199c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a4706db57ed7cc68d9897b06df02ed002ce206633eec05690d504d61789ae87db019",
 		);
 	});
 });

--- a/libs/as-sdk/assembly/bindings/seda_v1.ts
+++ b/libs/as-sdk/assembly/bindings/seda_v1.ts
@@ -23,3 +23,5 @@ export declare function secp256k1_verify(
 	public_key: usize,
 	public_key_length: u32,
 ): u8;
+
+export declare function keccak256(message: usize, message_length: u32): u32;

--- a/libs/as-sdk/assembly/bytes.ts
+++ b/libs/as-sdk/assembly/bytes.ts
@@ -234,6 +234,41 @@ export class Bytes {
 	}
 
 	/**
+	 * Create a new Bytes instance which is a combination of the first instance and the argument.
+	 *
+	 * @example
+	 * ```ts
+		const part1 = Bytes.fromUtf8String("Hello, ");
+		const part2 = Bytes.fromUtf8String("world!");
+
+		const combined = part1.concat(part2);
+
+		Console.log(combined.toUtf8String()); // "Hello, world!"
+	 * ```
+	 * @param bytes the bytes to add to this instance
+	 */
+	concat(bytes: Bytes): Bytes {
+		return Bytes.concat([this, bytes]);
+	}
+
+	static concat(bytes: Bytes[]): Bytes {
+		const newLength = bytes.reduce(
+			(total, current) => total + current.length,
+			0,
+		);
+		const newByteArray = new Uint8Array(newLength);
+
+		let offset = 0;
+		for (let index = 0; index < bytes.length; index++) {
+			const current = bytes[index];
+			newByteArray.set(current.value, offset);
+			offset = offset + current.length;
+		}
+
+		return Bytes.fromByteArray(newByteArray);
+	}
+
+	/**
 	 * Attempts to deserialize the Bytes into the '@json' annotated class `<T>`.
 	 * @example
 	 * ```ts

--- a/libs/as-sdk/assembly/index.ts
+++ b/libs/as-sdk/assembly/index.ts
@@ -29,7 +29,7 @@ export {
 	HttpResponse,
 } from "./http";
 
-export { proxyHttpFetch } from "./proxy-http";
+export { proxyHttpFetch, generateProxyHttpSigningMessage } from "./proxy-http";
 
 // Export library so consumers don't need to reimport it themselves
 export { JSON } from "json-as/assembly";

--- a/libs/as-sdk/assembly/index.ts
+++ b/libs/as-sdk/assembly/index.ts
@@ -13,6 +13,9 @@
  * @categoryDescription Tally
  * Classes to retrieve the execution reports from the overlay nodes.
  *
+ * @categoryDescription Crypto
+ * Functions to calculate hashes and verify cryptographic signatures.
+ *
  * @module @seda-protocol/as-sdk
  */
 
@@ -37,4 +40,4 @@ export { Console } from "./console";
 export { Bytes } from "./bytes";
 export { decodeHex, encodeHex } from "./hex";
 export { OracleProgram } from "./oracle-program";
-export { secp256k1Verify } from "./crypto";
+export { secp256k1Verify, keccak256 } from "./crypto";

--- a/libs/as-sdk/assembly/proxy-http.ts
+++ b/libs/as-sdk/assembly/proxy-http.ts
@@ -1,5 +1,7 @@
 import { JSON } from "json-as/assembly";
 import { call_result_write, proxy_http_fetch } from "./bindings/seda_v1";
+import { Bytes } from "./bytes";
+import { keccak256 } from "./crypto";
 import { HttpFetchAction, HttpFetchOptions, HttpResponse } from "./http";
 // Is used in the transform (because ProxyHttpFetchAction extends from HttpFetchAction)
 import { SerializableHttpFetchOptions } from "./http";
@@ -71,4 +73,63 @@ export function proxyHttpFetch(
 	}
 
 	return promise.unwrapRejected();
+}
+
+/**
+ * Generates the message which the data proxy hashed and signed. This can be useful when you need to verify
+ * the data proxy signature in the tally phase. With this message there is no need to include the entire request
+ * and response data in the execution result.
+ *
+ * @category HTTP
+ *
+ * @example
+ * ```ts
+ * @json
+ * class ApiResponse {
+ *   name!: string;
+ * }
+ *
+ * @json
+ * class ExecutionResult {
+ *   name!: string;
+ *   proxyMessage!: string;
+ * }
+ *
+ * const url = "https://swapi.dev/api/planets/1/";
+ * const response = proxyHttpFetch(url);
+ *
+ * if (response.ok) {
+ *   const proxyMessage = generateProxyHttpSigningMessage(url, "GET", Bytes.empty(), response.bytes);
+ *   const data = response.bytes.toJSON<ApiResponse>();
+ *
+ *   Process.success(Bytes.fromJSON<>({ name: data.name, proxyMessage: proxyMessage }));
+ * } else {
+ *   // Error occured
+ * }
+ * ```
+ * @param requestUrl
+ * @param requestMethod
+ * @param requestBody
+ * @param responseBody
+ * @returns the message that the data proxy should have hashed and signed
+ */
+export function generateProxyHttpSigningMessage(
+	requestUrl: string,
+	requestMethod: string,
+	requestBody: Bytes,
+	responseBody: Bytes,
+): Bytes {
+	const requestUrlHash = keccak256(Bytes.fromUtf8String(requestUrl));
+	const requestMethodHash = keccak256(
+		Bytes.fromUtf8String(requestMethod.toUpperCase()),
+	);
+	const requestBodyHash = keccak256(requestBody);
+	const responseBodyHash = keccak256(responseBody);
+
+	return Bytes.concat([
+		requestUrlHash,
+		requestMethodHash,
+		requestBodyHash,
+		responseBodyHash,
+	]);
 }

--- a/libs/as-sdk/package.json
+++ b/libs/as-sdk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/as-sdk",
 	"type": "module",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"types": "./assembly/index.ts",
 	"dependencies": {
 		"@assemblyscript/wasi-shim": "git+https://github.com/sedaprotocol/wasi-shim.git",

--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",

--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -19,7 +19,7 @@
 		"@cosmjs/stargate": "^0.32.3",
 		"@cosmjs/tendermint-rpc": "^0.32.3",
 		"@seda-protocol/proto-messages": "0.3.0-dev.0-1",
-		"@seda-protocol/vm": "^0.0.3",
+		"@seda-protocol/vm": "^0.0.4",
 		"big.js": "^6.2.1",
 		"dotenv": "^16.3.1",
 		"node-fetch": "^3.3.2",

--- a/libs/vm/package.json
+++ b/libs/vm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/vm",
 	"type": "module",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"dependencies": {
 		"@wasmer/wasi": "^1.2.2",
 		"true-myth": "^7.3.0",

--- a/libs/vm/src/vm-imports.ts
+++ b/libs/vm/src/vm-imports.ts
@@ -116,6 +116,28 @@ export default class VmImports {
 		}
 	}
 
+	keccak256(messagePtr: number, messageLength: number) {
+		const message = Buffer.from(
+			new Uint8Array(
+				this.memory?.buffer.slice(messagePtr, messagePtr + messageLength) ?? [],
+			),
+		);
+
+		const result = trySync(() => keccak256(message));
+
+		if (result.isErr) {
+			console.error(
+				`[${this.processId}] - @keccak256: ${message}`,
+				result.error,
+			);
+			this.callResult = new Uint8Array();
+			return 0;
+		}
+
+		this.callResult = result.value;
+		return this.callResult.length;
+	}
+
 	secp256k1Verify(
 		messagePtr: number,
 		messageLength: bigint,
@@ -191,6 +213,7 @@ export default class VmImports {
 				proxy_http_fetch: this.httpFetch.bind(this),
 				http_fetch: this.httpFetch.bind(this),
 				secp256k1_verify: this.secp256k1Verify.bind(this),
+				keccak256: this.keccak256.bind(this),
 				call_result_write: this.callResultWrite.bind(this),
 				execution_result: this.executionResult.bind(this),
 			},


### PR DESCRIPTION
## Motivation

Allow users to implement data proxy signature verification in their Oracle Programs, as well as convenience methods to make this easier.

## Explanation of Changes

Add Bytes.concat convenience methods. Both a static variant as well as a method on the instance.
Add keccak256 import binding to the VM.
Add keccak256 hashing function to the SDK utilising the import.
Add method to generate the message for a proxy http fetch.

## Testing

Added tests for all new functions. Verified the message generation with the data-proxy-sdk method.

## Related PRs and Issues

N.A.