### PR TITLE
Add support for DR bundle methods

### DIFF
--- a/libs/dev-tools/src/index.ts
+++ b/libs/dev-tools/src/index.ts
@@ -5,10 +5,15 @@ export { uploadWasmBinary } from "@dev-tools/services/wasm/upload-wasm-binary";
 export { getWasmBinary } from "@dev-tools/services/wasm/get-wasm-binary";
 
 export { postDataRequest } from "@dev-tools/services/dr/post-data-request";
+export { postDataRequestBundle } from "@dev-tools/services/dr/post-data-request-bundle";
 export { getDataRequestStatus } from "@dev-tools/services/dr/get-data-request-status";
+export { getDataRequestBundleStatus } from "@dev-tools/services/dr/get-data-request-bundle-status";
 export { awaitDataResult } from "@dev-tools/services/dr/await-data-result";
+export { awaitDataResultBundle } from "@dev-tools/services/dr/await-data-result-bundle";
 export { getDataResult } from "@dev-tools/services/dr/get-data-result";
+export { getDataResultBundle } from "@dev-tools/services/dr/get-data-result-bundle";
 export { postAndAwaitDataRequest } from "@dev-tools/services/dr/post-and-await-data-request";
+export { postAndAwaitDataRequestBundle } from "@dev-tools/services/dr/post-and-await-data-request-bundle";
 
 export * from "./lib/testing/create-mock-reveal";
 export * from "./lib/testing/create-mock-tally-args";

--- a/libs/dev-tools/src/lib/services/dr/get-data-request-bundle-status.ts
+++ b/libs/dev-tools/src/lib/services/dr/get-data-request-bundle-status.ts
@@ -1,0 +1,31 @@
+import { tryAsync } from "@dev-tools/utils/try-async";
+import type { ISigner } from "../signer";
+import {
+	type DataRequestStatus,
+	getDataRequestStatus,
+} from "./get-data-request-status";
+
+type StatusBatchResponse = {
+	drId: string;
+	status: DataRequestStatus | null;
+	error?: string;
+};
+
+export async function getDataRequestBundleStatus(
+	signer: ISigner,
+	drIds: string[],
+): Promise<StatusBatchResponse[]> {
+	return Promise.all(
+		drIds.map(async (drId) => {
+			const status = await tryAsync(() => getDataRequestStatus(signer, drId));
+			return status.mapOrElse<StatusBatchResponse>(
+				(error) => {
+					return { drId, status: null, error };
+				},
+				({ status }) => {
+					return { drId, status, error: undefined };
+				},
+			);
+		}),
+	);
+}

--- a/libs/dev-tools/src/lib/services/dr/get-data-request-status.ts
+++ b/libs/dev-tools/src/lib/services/dr/get-data-request-status.ts
@@ -2,7 +2,11 @@ import assert from "node:assert";
 import type { ISigner } from "../signer";
 import { createSigningClient } from "../signing-client";
 
-type DataRequestStatus = "pending" | "committing" | "revealing" | "resolved";
+export type DataRequestStatus =
+	| "pending"
+	| "committing"
+	| "revealing"
+	| "resolved";
 
 export async function getDataRequestStatus(
 	signer: ISigner,

--- a/libs/dev-tools/src/lib/services/dr/get-data-result-bundle.ts
+++ b/libs/dev-tools/src/lib/services/dr/get-data-result-bundle.ts
@@ -1,0 +1,28 @@
+import { tryAsync } from "@dev-tools/utils/try-async";
+import type { ISigner } from "../signer";
+import { type DataRequestResult, getDataResult } from "./get-data-result";
+
+type ResultBatchResponse = {
+	drId: string;
+	result: DataRequestResult | null;
+	error?: string;
+};
+
+export async function getDataResultBundle(
+	signer: ISigner,
+	drIds: string[],
+): Promise<ResultBatchResponse[]> {
+	return Promise.all(
+		drIds.map(async (drId) => {
+			const status = await tryAsync(() => getDataResult(signer, drId));
+			return status.mapOrElse<ResultBatchResponse>(
+				(error) => {
+					return { drId, result: null, error };
+				},
+				(result) => {
+					return { drId, result, error: undefined };
+				},
+			);
+		}),
+	);
+}

--- a/libs/dev-tools/src/lib/services/dr/get-data-result.ts
+++ b/libs/dev-tools/src/lib/services/dr/get-data-result.ts
@@ -41,10 +41,12 @@ const DataResultSchema = pipe(
 	}),
 );
 
+export type DataRequestResult = InferOutput<typeof DataResultSchema>;
+
 export async function getDataResult(
 	signer: ISigner,
 	drId: string,
-): Promise<InferOutput<typeof DataResultSchema>> {
+): Promise<DataRequestResult> {
 	const sigingClientResult = await createSigningClient(signer);
 	if (sigingClientResult.isErr) {
 		throw sigingClientResult.error;

--- a/libs/dev-tools/src/lib/services/dr/post-and-await-data-request-bundle.ts
+++ b/libs/dev-tools/src/lib/services/dr/post-and-await-data-request-bundle.ts
@@ -1,0 +1,28 @@
+import type { GasOptions } from "@dev-tools/services/gas-options";
+import type { ISigner } from "@dev-tools/services/signer";
+import { awaitDataResultBundle } from "./await-data-result-bundle";
+import type { PostDataRequestInput } from "./create-dr-input";
+import { postDataRequestBundle } from "./post-data-request-bundle";
+
+type AwaitOptions = Parameters<typeof awaitDataResultBundle>["2"];
+
+export async function postAndAwaitDataRequestBundle(
+	signer: ISigner,
+	dataRequestInputs: PostDataRequestInput[],
+	gasOptions?: GasOptions,
+	awaitOptions?: AwaitOptions,
+) {
+	const postDrResponse = await postDataRequestBundle(
+		signer,
+		dataRequestInputs,
+		gasOptions,
+	);
+
+	const dataResults = await awaitDataResultBundle(
+		signer,
+		postDrResponse.drIds,
+		awaitOptions,
+	);
+
+	return dataResults;
+}

--- a/libs/dev-tools/src/lib/services/dr/post-data-request-bundle.ts
+++ b/libs/dev-tools/src/lib/services/dr/post-data-request-bundle.ts
@@ -1,0 +1,68 @@
+import type { GasOptions } from "../gas-options";
+import { signAndSendTx } from "../sign-and-send-tx";
+import type { ISigner } from "../signer";
+import { createSigningClient } from "../signing-client";
+import {
+	type PostDataRequestInput,
+	createPostedDataRequest,
+} from "./create-dr-input";
+
+export async function postDataRequestBundle(
+	signer: ISigner,
+	dataRequestInputs: PostDataRequestInput[],
+	gasOptions?: GasOptions,
+): Promise<{ tx: string; drIds: string[] }> {
+	const sigingClientResult = await createSigningClient(signer);
+	if (sigingClientResult.isErr) {
+		throw sigingClientResult.error;
+	}
+
+	const contract = signer.getCoreContractAddress();
+
+	const { client: sigingClient, address } = sigingClientResult.value;
+
+	const messages = dataRequestInputs.map((dataRequestInput) => {
+		return {
+			typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
+			value: {
+				sender: address,
+				contract,
+				msg: Buffer.from(
+					JSON.stringify({
+						post_data_request: {
+							seda_payload: Buffer.from([]).toString("base64"),
+							payback_address: Buffer.from("seda_sdk").toString("base64"),
+							posted_dr: createPostedDataRequest(dataRequestInput),
+						},
+					}),
+				),
+			},
+		};
+	});
+
+	const response = await signAndSendTx(
+		sigingClient,
+		address,
+		messages,
+		gasOptions,
+	);
+
+	if (response.isErr) {
+		throw response.error;
+	}
+
+	if (response.value.code === 1) {
+		throw new Error(`TX failed: "${response.value.transactionHash}"`);
+	}
+
+	const drIds = response.value.msgResponses.map((messageResponseRaw) => {
+		const messageResponse = sigingClient.registry.decode(messageResponseRaw);
+
+		return JSON.parse(Buffer.from(messageResponse.data).toString());
+	});
+
+	return {
+		tx: response.value.transactionHash,
+		drIds,
+	};
+}


### PR DESCRIPTION
## Motivation

Make it easier to post several DRs in one go.

## Explanation of Changes

Added `Bundle` versions of all DR related methods.

## Testing

I used the following script to test the `postAndAwaitDataRequestBundle`

```ts
import { Signer, buildSigningConfig, postAndAwaitDataRequestBundle } from "./";

async function main() {
	const signingConfig = buildSigningConfig({});
	const signer = await Signer.fromPartial(signingConfig);

	console.log("Posting and waiting for results, this may take a lil while..");

	const result = await postAndAwaitDataRequestBundle(
		signer,
		[
			"eth-usdc",
			"sol-btc",
		].map((pair) => {
			return {
				consensusOptions: {
					method: "none",
				},
				oracleProgramId:
					"470fca08d461761f16d42a357d04732524c85f00e32e0360a246a9396a9d2fc0",
				drInputs: Buffer.from(pair),
				tallyInputs: Buffer.from([]),
				memo: Buffer.from(`pair_${pair}_${new Date().toISOString()}`),
			};
		}),
		undefined,
		{ timeoutSeconds: 300, pollingIntervalSeconds: 10 },
	);

	console.table(result);
}

main();
```

## Related PRs and Issues

N.A.
