### PR TITLE
fix(dev-tools): display the oracle program id as hex

### DIFF
--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",

--- a/libs/dev-tools/src/cli/oracle-program/upload.ts
+++ b/libs/dev-tools/src/cli/oracle-program/upload.ts
@@ -53,9 +53,7 @@ upload.action(async () => {
 			// There is already an Oracle Program with the same hash on chain
 			spinnerSuccess();
 			console.table({
-				oracleProgramId: Buffer.from(
-					existingOracleProgram.value.value.oracleProgramId,
-				).toString("hex"),
+				oracleProgramId: existingOracleProgram.value.value.oracleProgramId,
 			});
 			process.exit(0);
 		}


### PR DESCRIPTION
## Motivation

Less confusing.

## Explanation of Changes

Instead of a hex representation of a hex string.

## Testing

Built the CLI and uploaded an existing WASM.

<img width="1000" alt="Screenshot 2024-10-09 at 21 59 21" src="https://github.com/user-attachments/assets/771fd483-7a3b-4674-bee4-a7b372ac447c">

## Related PRs and Issues

N.A.
