### PR TITLE
Update DR fields

### DIFF
--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -18,7 +18,7 @@
 		"@cosmjs/proto-signing": "^0.32.4",
 		"@cosmjs/stargate": "^0.32.4",
 		"@cosmjs/tendermint-rpc": "^0.32.4",
-		"@seda-protocol/proto-messages": "0.3.0-dev.0-1",
+		"@seda-protocol/proto-messages": "0.4.0-dev.3",
 		"@seda-protocol/utils": "^1.2.0",
 		"@seda-protocol/vm": "^0.0.4",
 		"big.js": "^6.2.1",

--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "0.0.14",
+	"version": "0.0.15",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",

--- a/libs/dev-tools/src/lib/services/dr/create-dr-input.ts
+++ b/libs/dev-tools/src/lib/services/dr/create-dr-input.ts
@@ -5,8 +5,8 @@ import {
 
 const DEFAULT_VERSION = "0.0.1";
 const DEFAULT_REPLICATION_FACTOR = 1;
-const DEFAULT_GAS_LIMIT = 5_000_000_000;
-const DEFAULT_GAS_PRICE = 1;
+const DEFAULT_GAS_LIMIT = 300_000_000_000_000;
+const DEFAULT_GAS_PRICE = 1n;
 const DEFAULT_MEMO = new Uint8Array([]);
 
 export type PostDataRequestInput = {
@@ -20,6 +20,11 @@ export type PostDataRequestInput = {
 	 * Execution phase inputs encoded as bytes. Input depends on the Oracle Program specified in execProgramId.
 	 */
 	execInputs: Uint8Array;
+	/**
+	 * Amount of gas units allowed for execution
+	 * Defaults to 300_000_000_000_000 (max gas limit)
+	 */
+	execGasLimit?: number;
 
 	/**
 	 * Hash of the uploaded Tally Oracle Program that should run the tally phase.
@@ -30,6 +35,11 @@ export type PostDataRequestInput = {
 	 * Inputs encoded in bytes. Input depends on the Tally Oracle Program specified in tallyProgramId.
 	 */
 	tallyInputs: Uint8Array;
+	/**
+	 * Amount of gas units allowed for tally
+	 * Defaults to 300_000_000_000_000 (max gas limit)
+	 */
+	tallyGasLimit?: number;
 
 	/**
 	 * Amount of overlay nodes required to execute this Data Request
@@ -46,15 +56,9 @@ export type PostDataRequestInput = {
 
 	/**
 	 * How much aseda you want to pay per gas unit
-	 * Defaults to 1
+	 * Defaults to 1n (bigint)
 	 */
-	gasPrice?: number;
-
-	/**
-	 * Amount of gas units allowed for execution
-	 * Defaults to 300_000
-	 */
-	gasLimit?: number;
+	gasPrice?: bigint;
 
 	/**
 	 * Memo field for any data you want to attach to the Data Request
@@ -79,7 +83,8 @@ export function createPostedDataRequest(input: PostDataRequestInput) {
 		encodeConsensusFilter(input.consensusOptions),
 	);
 
-	const gas_limit = input.gasLimit ?? DEFAULT_GAS_LIMIT;
+	const exec_gas_limit = input.execGasLimit ?? DEFAULT_GAS_LIMIT;
+	const tally_gas_limit = input.tallyGasLimit ?? DEFAULT_GAS_LIMIT;
 	const gas_price = (input.gasPrice ?? DEFAULT_GAS_PRICE).toString();
 
 	const memo = base64Encode(input.memo ?? DEFAULT_MEMO);
@@ -92,7 +97,8 @@ export function createPostedDataRequest(input: PostDataRequestInput) {
 		tally_inputs,
 		replication_factor,
 		consensus_filter,
-		gas_limit,
+		exec_gas_limit,
+		tally_gas_limit,
 		gas_price,
 		memo,
 	};

--- a/libs/dev-tools/src/lib/services/dr/get-data-result.ts
+++ b/libs/dev-tools/src/lib/services/dr/get-data-result.ts
@@ -2,6 +2,7 @@ import { tryAsync } from "@seda-protocol/utils";
 import { Maybe } from "true-myth";
 import {
 	type InferOutput,
+	bigint,
 	boolean,
 	custom,
 	number,
@@ -16,13 +17,16 @@ import { createBatchingQueryClient } from "./query-client";
 
 const DataResultSchema = pipe(
 	object({
+		id: string(),
 		version: string(),
 		drId: string(),
+		drBlockHeight: bigint(),
 		consensus: boolean(),
 		exitCode: number(),
 		result: custom<Uint8Array>((input) => input instanceof Uint8Array),
-		blockHeight: number(),
-		gasUsed: number(),
+		blockHeight: bigint(),
+		blockTimestamp: bigint(),
+		gasUsed: bigint(),
 		paybackAddress: string(),
 		sedaPayload: string(),
 	}),
@@ -32,11 +36,13 @@ const DataResultSchema = pipe(
 		return {
 			version: result.version,
 			drId: result.drId,
+			drBlockHeight: result.drBlockHeight,
 			consensus: result.consensus,
 			exitCode: result.exitCode,
 			result: `0x${resultBuffer.toString("hex")}`,
 			resultAsUtf8: resultBuffer.toString(),
 			blockHeight: result.blockHeight,
+			blockTimestamp: new Date(Number(result.blockTimestamp * 1000n)),
 			gasUsed: result.gasUsed,
 			paybackAddress: base64Decode(result.paybackAddress),
 			sedaPayload: base64Decode(result.sedaPayload),

--- a/libs/proto-messages/gen/index.ts
+++ b/libs/proto-messages/gen/index.ts
@@ -7,8 +7,8 @@
 
 export * as google from "./index.google";
 export * as gogoproto from "./index.gogoproto";
-export * as cosmos_proto from "./index.cosmos_proto";
 export * as sedachain from "./index.sedachain";
 export * as cosmos from "./index.cosmos";
+export * as cosmos_proto from "./index.cosmos_proto";
 export * as amino from "./index.amino";
 export * as tendermint from "./index.tendermint";

--- a/libs/proto-messages/package.json
+++ b/libs/proto-messages/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/proto-messages",
 	"type": "module",
-	"version": "0.4.0-dev.2",
+	"version": "0.4.0-dev.3",
 	"scripts": {
 		"build": "bunx buf generate",
 		"prepublish": "bun run build"

--- a/libs/proto-messages/proto/sedachain/batching/v1/batching.proto
+++ b/libs/proto-messages/proto/sedachain/batching/v1/batching.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 package sedachain.batching.v1;
 
 import "gogoproto/gogo.proto";
-import "cosmos_proto/cosmos.proto";
 
 option go_package = "github.com/sedaprotocol/seda-chain/x/batching/types";
 
@@ -25,38 +24,30 @@ message Batch {
   string validator_root = 5;
   // batch_id is the Keccack-256 hash of the batch content.
   bytes batch_id = 6;
-  // proving_medatada is a field for additional proving data.
-  bytes proving_medatada = 7;
+  // proving_metadata is a field for additional proving data.
+  bytes proving_metadata = 7;
 }
 
-// TreeEntries are the given batch's data result tree entries and
-// validator tree entries.
-message TreeEntries {
-  // batch_number is the identifier of the batch the tree entries from.
-  uint64 batch_number = 1;
-  // data_result_entries are the entries (unhashed leaf contents) of
-  // the data result tree.
-  repeated bytes data_result_entries = 2;
-  // validator_entries are the entries (unhashed leaf contents) of
-  // the validator tree.
-  repeated bytes validator_entries = 3;
+// DataResultTreeEntries is a list of data result tree entries for a
+// given batch.
+message DataResultTreeEntries { repeated bytes entries = 1; }
+
+// ValidatorTreeEntry is an entry in the validator tree.
+message ValidatorTreeEntry {
+  bytes validator_address = 1
+      [ (gogoproto.casttype) =
+            "github.com/cosmos/cosmos-sdk/types.ValAddress" ];
+  uint32 voting_power_percent = 2;
+  bytes eth_address = 3;
 }
 
 // BatchSignatures contains basic validator data and its batch signatures
 // under various cryptographic schemes.
 message BatchSignatures {
-  string validator_addr = 1
-      [ (cosmos_proto.scalar) = "cosmos.ValidatorAddressString" ];
-  bytes signatures = 2;
-}
-
-// Params is a list of parameters which can be changed through governance.
-message Params {
-  option (gogoproto.equal) = true;
-
-  // validator_set_trim_percent is the percentage of the validator
-  // set to store in the validator merkle tree in the batch.
-  uint32 validator_set_trim_percent = 1;
+  bytes validator_address = 1
+      [ (gogoproto.casttype) =
+            "github.com/cosmos/cosmos-sdk/types.ValAddress" ];
+  bytes secp256k1_signature = 2;
 }
 
 // DataResult represents the result of a resolved data request.
@@ -65,22 +56,27 @@ message DataResult {
   string id = 1 [ (gogoproto.jsontag) = "id" ];
   // dr_id is the data request identifier.
   string dr_id = 2 [ (gogoproto.jsontag) = "dr_id" ];
+  // dr_block_height is the height at which the data request was submitted.
+  uint64 dr_block_height = 3 [ (gogoproto.jsontag) = "dr_block_height" ];
   // version is a semantic version string.
-  string version = 3 [ (gogoproto.jsontag) = "version" ];
+  string version = 4 [ (gogoproto.jsontag) = "version" ];
   // block_height is the height at which the data request was tallied.
-  uint64 block_height = 4 [ (gogoproto.jsontag) = "block_height" ];
+  uint64 block_height = 5 [ (gogoproto.jsontag) = "block_height" ];
+  // block_timestamp is the unix timestamp in seconds of when the data request
+  // was tallied.
+  uint64 block_timestamp = 6 [ (gogoproto.jsontag) = "block_timestamp" ];
   // exit_code is the exit code of the tally wasm binary execution.
-  uint32 exit_code = 5 [ (gogoproto.jsontag) = "exit_code" ];
+  uint32 exit_code = 7 [ (gogoproto.jsontag) = "exit_code" ];
   // gas_used is the gas used by the data request execution.
-  uint64 gas_used = 6 [ (gogoproto.jsontag) = "gas_used" ];
+  uint64 gas_used = 8 [ (gogoproto.jsontag) = "gas_used" ];
   // result is the result of the tally wasm binary execution.
-  bytes result = 7 [ (gogoproto.jsontag) = "result" ];
+  bytes result = 9 [ (gogoproto.jsontag) = "result" ];
   // payback_address is the payback address set by the relayer.
-  string payback_address = 8 [ (gogoproto.jsontag) = "payback_address" ];
+  string payback_address = 10 [ (gogoproto.jsontag) = "payback_address" ];
   // seda_payload is the payload set by SEDA Protocol (e.g. OEV-enabled
   // data requests)
-  string seda_payload = 9 [ (gogoproto.jsontag) = "seda_payload" ];
+  string seda_payload = 11 [ (gogoproto.jsontag) = "seda_payload" ];
   // consensus indicates whether consensus was reached in the tally
   // process.
-  bool consensus = 10 [ (gogoproto.jsontag) = "consensus" ];
+  bool consensus = 12 [ (gogoproto.jsontag) = "consensus" ];
 }

--- a/libs/proto-messages/proto/sedachain/batching/v1/genesis.proto
+++ b/libs/proto-messages/proto/sedachain/batching/v1/genesis.proto
@@ -12,11 +12,10 @@ message GenesisState {
   // created batch.
   uint64 current_batch_number = 1;
   repeated Batch batches = 2 [ (gogoproto.nullable) = false ];
-  repeated TreeEntries tree_entries = 3 [ (gogoproto.nullable) = false ];
+  repeated BatchData batch_data = 3 [ (gogoproto.nullable) = false ];
   repeated DataResult data_results = 4 [ (gogoproto.nullable) = false ];
   repeated BatchAssignment batch_assignments = 5
       [ (gogoproto.nullable) = false ];
-  Params params = 6 [ (gogoproto.nullable) = false ];
 }
 
 // BatchAssignment represents a batch assignment for genesis export
@@ -24,4 +23,15 @@ message GenesisState {
 message BatchAssignment {
   uint64 batch_number = 1;
   string data_request_id = 2;
+}
+
+// BatchData represents a given batch's full data.
+message BatchData {
+  uint64 batch_number = 1;
+  DataResultTreeEntries data_result_entries = 2
+      [ (gogoproto.nullable) = false ];
+  repeated ValidatorTreeEntry validator_entries = 3
+      [ (gogoproto.nullable) = false ];
+  repeated BatchSignatures batch_signatures = 4
+      [ (gogoproto.nullable) = false ];
 }

--- a/libs/proto-messages/proto/sedachain/batching/v1/query.proto
+++ b/libs/proto-messages/proto/sedachain/batching/v1/query.proto
@@ -5,6 +5,7 @@ import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 import "sedachain/batching/v1/batching.proto";
+import "sedachain/batching/v1/genesis.proto";
 
 option go_package = "github.com/sedaprotocol/seda-chain/x/batching/types";
 
@@ -27,33 +28,11 @@ service Query {
     option (google.api.http).get = "/seda-chain/batching/batches";
   }
 
-  // TreeEntries returns the tree entries from the given batch number.
-  rpc TreeEntries(QueryTreeEntriesRequest) returns (QueryTreeEntriesResponse) {
-    option (google.api.http).get =
-        "/seda-chain/batching/tree_entries/{batch_number}";
-  }
-
-  // BatchSignatures returns the batch signatures for the given batch
-  // and the
-  rpc BatchSignatures(QueryBatchSignaturesRequest)
-      returns (QueryBatchSignaturesResponse) {
-    option (google.api.http).get =
-        "/seda-chain/batching/batch_signatures/{batch_number}";
-  }
-
   // DataResult returns a data result given its associated data request's
   // ID.
   rpc DataResult(QueryDataResultRequest) returns (QueryDataResultResponse) {
     option (google.api.http).get =
         "/seda-chain/batching/data_result/{data_request_id}";
-  }
-
-  // BatchAssignment returns the batch number that a given data request
-  // has been assigned to.
-  rpc BatchAssignment(QueryBatchAssignmentRequest)
-      returns (QueryBatchAssignmentResponse) {
-    option (google.api.http).get =
-        "/seda-chain/batching/batch_assignment/{data_request_id}";
   }
 }
 
@@ -61,7 +40,15 @@ service Query {
 message QueryBatchRequest { uint64 batch_number = 1; }
 
 // The response message for QueryBatch RPC.
-message QueryBatchResponse { Batch batch = 1 [ (gogoproto.nullable) = false ]; }
+message QueryBatchResponse {
+  Batch batch = 1 [ (gogoproto.nullable) = false ];
+  DataResultTreeEntries data_result_entries = 2
+      [ (gogoproto.nullable) = false ];
+  repeated ValidatorTreeEntry validator_entries = 3
+      [ (gogoproto.nullable) = false ];
+  repeated BatchSignatures batch_signatures = 4
+      [ (gogoproto.nullable) = false ];
+}
 
 // The request message for BatchForHeight RPC.
 message QueryBatchForHeightRequest { int64 block_height = 1; }
@@ -75,6 +62,9 @@ message QueryBatchForHeightResponse {
 message QueryBatchesRequest {
   // pagination defines an optional pagination for the request.
   cosmos.base.query.v1beta1.PageRequest pagination = 1;
+  // with_unsigned indicates whether to return batches without
+  // signatures or not.
+  bool with_unsigned = 2;
 }
 
 // The response message for QueryBatches RPC.
@@ -83,32 +73,11 @@ message QueryBatchesResponse {
   cosmos.base.query.v1beta1.PageResponse pagination = 2;
 }
 
-// The request message for QueryTreeEntries RPC.
-message QueryTreeEntriesRequest { uint64 batch_number = 1; }
-
-// The response message for QueryTreeEntries RPC.
-message QueryTreeEntriesResponse {
-  TreeEntries entries = 1 [ (gogoproto.nullable) = false ];
-}
-
-// The request message for QueryBatchSignaturesRequest RPC.
-message QueryBatchSignaturesRequest { uint64 batch_number = 1; }
-
-// The response message for QueryQueryBatchSignatures RPC.
-message QueryBatchSignaturesResponse {
-  repeated BatchSignatures batch_sigs = 1 [ (gogoproto.nullable) = false ];
-}
-
 // The request message for QueryDataResult RPC.
 message QueryDataResultRequest { string data_request_id = 1; }
 
 // The response message for QueryDataResult RPC.
 message QueryDataResultResponse {
   DataResult data_result = 1 [ (gogoproto.nullable) = true ];
+  BatchAssignment batch_assignment = 2;
 }
-
-// The request message for QueryBatchAssignment RPC.
-message QueryBatchAssignmentRequest { string data_request_id = 1; }
-
-// The response message for QueryBatchAssignment RPC.
-message QueryBatchAssignmentResponse { uint64 batch_number = 1; }


### PR DESCRIPTION
## Motivation

Stay up to date with the latest changes of the protocol

## Explanation of Changes

bump proto-messages version to `v0.4.0-dev.3`
bump dev-tools version to `v0.0.15`

## Testing

Tested by deploying the latest contract on a local chain running the latest version of main. Posting a DR succeeds, and the result can be queried:

```ts
 {
  version: "0.0.1",
  drId: "150ac588497094491516feecd60318053c7a5f27f89e18fce247140e3e446f19",
  drBlockHeight: 172n,
  consensus: false,
  exitCode: 200,
  result: "0x6e656564203120636f6d6d6974733b2072656365697665642030",
  resultAsUtf8: "need 1 commits; received 0",
  blockHeight: 182n,
  blockTimestamp: 2024-11-28T12:49:48.000Z,
  gasUsed: 0n,
  paybackAddress: "seda_sdk",
  sedaPayload: "",
}
```

The DRs just timed out, as I didn't bother running an overlay node locally and uploading oracle programs.

## Related PRs and Issues

Closes: #110 
