### PR TITLE
fix: typo Update as-pect.config.js

### DIFF
--- a/libs/as-sdk/as-pect.config.js
+++ b/libs/as-sdk/as-pect.config.js
@@ -8,7 +8,7 @@ export default {
 	 */
 	include: ["./assembly/__test__/**/*.include.ts"],
 	/**
-	 * A set of regexp that will disclude source files from testing.
+	 * A set of regexp that will exclude source files from testing.
 	 */
 	disclude: [/node_modules/],
 	/**


### PR DESCRIPTION
I've corrected the incorrect usage of the word "disclude" to the proper term "exclude."
The word "disclude" is not recognized in standard English, and "exclude" should be used instead to maintain clarity and correctness.

This fix ensures the text aligns with proper language standards and improves the overall readability of the code/documentation. 
