### PR TITLE
Reveal gas_used is now a uint64

### DIFF
--- a/libs/as-sdk-integration-tests/src/tallyvm.test.ts
+++ b/libs/as-sdk-integration-tests/src/tallyvm.test.ts
@@ -107,7 +107,7 @@ describe("TallyVm", () => {
 
 		expect(result.exitCode).toBe(0);
 		expect(result.resultAsString).toBe(
-			'[{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":0,"gasUsed":"200000","reveal":{"type":"hex","value":"7b2264617461223a22626162795f736861726b227d"},"inConsensus":true},{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":1,"gasUsed":"1336","reveal":{"type":"hex","value":"7b2264617461223a226772616e6470615f736861726b227d"},"inConsensus":true},{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":0,"gasUsed":"12","reveal":{"type":"hex","value":"7b2264617461223a226772616e646d615f736861726b227d"},"inConsensus":false}]',
+			'[{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":0,"gasUsed":200000,"reveal":{"type":"hex","value":"7b2264617461223a22626162795f736861726b227d"},"inConsensus":true},{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":1,"gasUsed":1336,"reveal":{"type":"hex","value":"7b2264617461223a226772616e6470615f736861726b227d"},"inConsensus":true},{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":0,"gasUsed":12,"reveal":{"type":"hex","value":"7b2264617461223a226772616e646d615f736861726b227d"},"inConsensus":false}]',
 		);
 	});
 
@@ -141,7 +141,7 @@ describe("TallyVm", () => {
 
 		expect(result.exitCode).toBe(0);
 		expect(result.resultAsString).toBe(
-			'[{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":0,"gasUsed":"1336","reveal":{"type":"hex","value":"7b2264617461223a226772616e6470615f736861726b227d"},"inConsensus":true},{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":0,"gasUsed":"1346","reveal":{"type":"hex","value":"7b2264617461223a22636f7573696e5f736861726b227d"},"inConsensus":true}]',
+			'[{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":0,"gasUsed":1336,"reveal":{"type":"hex","value":"7b2264617461223a226772616e6470615f736861726b227d"},"inConsensus":true},{"salt":{"type":"hex","value":"736564615f73646b"},"exitCode":0,"gasUsed":1346,"reveal":{"type":"hex","value":"7b2264617461223a22636f7573696e5f736861726b227d"},"inConsensus":true}]',
 		);
 	});
 });

--- a/libs/as-sdk/assembly/tally.ts
+++ b/libs/as-sdk/assembly/tally.ts
@@ -10,7 +10,7 @@ const CONSENSUS_ARGUMENT_POSITION = 3;
 class RevealBody {
 	salt!: u8[];
 	exit_code!: u8;
-	gas_used!: string;
+	gas_used!: u64;
 	reveal!: u8[];
 }
 
@@ -35,7 +35,7 @@ export class RevealResult {
 	/**
 	 * Gas units consumed by the overlay node while executing the Oracle Program.
 	 */
-	gasUsed!: string;
+	gasUsed!: u64;
 
 	/**
 	 * The ouput of the execution phase of the Oracle Program.

--- a/libs/as-sdk/package.json
+++ b/libs/as-sdk/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/as-sdk",
 	"type": "module",
-	"version": "0.0.16",
+	"version": "0.0.17",
 	"types": "./assembly/index.ts",
 	"dependencies": {
 		"@assemblyscript/wasi-shim": "git+https://github.com/sedaprotocol/wasi-shim.git",

--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",

--- a/libs/dev-tools/src/lib/testing/create-mock-reveal.ts
+++ b/libs/dev-tools/src/lib/testing/create-mock-reveal.ts
@@ -24,7 +24,7 @@ export function createMockReveal(input: RevealInput) {
 	return {
 		salt: MOCK_SALT_BYTES,
 		exit_code: input.exitCode,
-		gas_used: input.gasUsed.toString(),
+		gas_used: input.gasUsed,
 		reveal: [...resultBytes],
 	};
 }


### PR DESCRIPTION
## Motivation

On the protocol side it has always been a uint64, we just never noticed since our oracle programs didn't use the field.

## Explanation of Changes

N.A.

## Testing

Updated the unit test.

## Related PRs and Issues

N.A.
