### PR TITLE
Update DR input options

### DIFF
--- a/libs/dev-tools/src/lib/services/dr/consensus-filter.test.ts
+++ b/libs/dev-tools/src/lib/services/dr/consensus-filter.test.ts
@@ -63,7 +63,7 @@ describe("encodeConsensusFilter", () => {
 					numberType: "int64",
 				},
 				expectedResult:
-					"02000000000016E36001000000000000000D242E726573756C742E74657874",
+					"02000000000016E36002000000000000000D242E726573756C742E74657874",
 			},
 			{
 				input: {
@@ -72,7 +72,24 @@ describe("encodeConsensusFilter", () => {
 					numberType: "int64",
 				},
 				expectedResult:
-					"02000000000007A12001000000000000000D242E726573756C742E74657874",
+					"02000000000007A12002000000000000000D242E726573756C742E74657874",
+			},
+			{
+				input: {
+					jsonPath: "$",
+					maxSigma: 1,
+					numberType: "uint128",
+				},
+				expectedResult: "0200000000000F424005000000000000000124",
+			},
+			{
+				input: {
+					jsonPath: "$[0].result.value",
+					maxSigma: 1,
+					numberType: "int256",
+				},
+				expectedResult:
+					"0200000000000F4240060000000000000011245B305D2E726573756C742E76616C7565",
 			},
 		] as const)("should encode a valid filter", ({ input, expectedResult }) => {
 			const result = encodeConsensusFilter({

--- a/libs/dev-tools/src/lib/services/dr/consensus-filter.ts
+++ b/libs/dev-tools/src/lib/services/dr/consensus-filter.ts
@@ -23,9 +23,13 @@ type ModeConsensusFilter = {
 const FILTER_METHOD_STD_DEV = 0x02;
 const stdDevNumberTypesMap = {
 	int32: 0x00,
-	int64: 0x01,
-	uint32: 0x02,
+	uint32: 0x01,
+	int64: 0x02,
 	uint64: 0x03,
+	int128: 0x04,
+	uint128: 0x05,
+	int256: 0x06,
+	uint256: 0x07,
 };
 
 type StdDevConsensusFilter = {

--- a/libs/dev-tools/src/lib/services/dr/create-dr-input.ts
+++ b/libs/dev-tools/src/lib/services/dr/create-dr-input.ts
@@ -6,8 +6,8 @@ import {
 const DEFAULT_VERSION = "0.0.1";
 const DEFAULT_REPLICATION_FACTOR = 1;
 const DEFAULT_EXEC_GAS_LIMIT = 300_000_000_000_000;
-const DEFAULT_TALLY_GAS_LIMIT = 150_000_000_000_000;
-const DEFAULT_GAS_PRICE = 1n;
+const DEFAULT_TALLY_GAS_LIMIT = 50_000_000_000_000;
+const DEFAULT_GAS_PRICE = 2_000n;
 const DEFAULT_MEMO = new Uint8Array([]);
 
 export type PostDataRequestInput = {
@@ -22,8 +22,8 @@ export type PostDataRequestInput = {
 	 */
 	execInputs: Uint8Array;
 	/**
-	 * Amount of gas units allowed for execution
-	 * Defaults to 300_000_000_000_000 (max gas limit)
+	 * Amount of gas units allowed for execution across all overlay nodes
+	 * Defaults to 300_000_000_000_000 (max gas limit per overlay node)
 	 */
 	execGasLimit?: number;
 
@@ -38,7 +38,7 @@ export type PostDataRequestInput = {
 	tallyInputs: Uint8Array;
 	/**
 	 * Amount of gas units allowed for tally
-	 * Defaults to 150_000_000_000_000 (max gas limit)
+	 * Defaults to 50_000_000_000_000 (max gas limit)
 	 */
 	tallyGasLimit?: number;
 
@@ -57,7 +57,7 @@ export type PostDataRequestInput = {
 
 	/**
 	 * How much aseda you want to pay per gas unit
-	 * Defaults to 1n (bigint)
+	 * Defaults to 2_000n (bigint)
 	 */
 	gasPrice?: bigint;
 


### PR DESCRIPTION
## Motivation

Update inputs to be compatible with the latest changes on chain

## Explanation of Changes

Update std-dev filter options and serialisation so it matches what is available on chain.

Set the default gasPrice to a sensible value. I'm open to different values, I just saw this come up the most in our models/discussions and I wanted to create the PR so it's off my mental todo list 😛 

Set the default tally gas limit to the current limit on chain.

## Testing

Posted DRs to a local network.

## Related PRs and Issues

Closes: #124 
