### PR TITLE
refactor(vm): expose worker and allow worker as a parameter

### DIFF
--- a/libs/vm/package.json
+++ b/libs/vm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/vm",
 	"type": "module",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"dependencies": {
 		"@seda-protocol/wasm-metering-ts": "https://github.com/sedaprotocol/wasm-metering-ts.git",
 		"@wasmer/wasi": "^1.2.2",


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Expose Worker as a function so it can be used to create your own Worker instance. This is required in order to make the overlay node embed the worker in the single binary.