### PR TITLE
Feat/debug log

### DIFF
--- a/libs/rs-sdk/sdk/src/lib.rs
+++ b/libs/rs-sdk/sdk/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bytes;
 pub mod errors;
 pub mod http;
 pub mod keccak256;
+pub mod log;
 pub mod process;
 pub mod promise;
 mod promise_actions;

--- a/libs/rs-sdk/sdk/src/log.rs
+++ b/libs/rs-sdk/sdk/src/log.rs
@@ -1,0 +1,43 @@
+/// A debug macro that prints the expression and its value to stderr.
+///
+/// This macro is a more gas-efficient alternative to the standard `dbg!` macro.
+/// It evaluates the given expression, prints the source location, expression text,
+/// and its debug representation to standard error.
+///
+/// # Examples
+///
+/// ```
+/// let a = 2;
+/// let b = debug!(a * 2) + 1;
+/// // Prints to stderr: [src/main.rs:2:9] a * 2 = 4
+/// assert_eq!(b, 5);
+/// ```
+///
+/// Multiple values can be debugged at once:
+///
+/// ```
+/// let x = 1;
+/// let y = 2;
+/// debug!(x, y, x + y);
+/// // Prints each value on a separate line with location information
+/// ```
+///
+/// # Notes
+///
+/// This macro requires that the expression's type implements the `Debug` trait.
+#[macro_export]
+macro_rules! debug {
+    ($expr:expr) => {
+        match $expr {
+            expr => {
+                // Format the debug message
+                std::io::stderr().write_all(format!("[{}:{}] {} = {:#?}\n", file!(), line!(), stringify!($expr), &expr).as_bytes())?;
+
+                expr
+            }
+        }
+    };
+    ($($val:expr),+ $(,)?) => {
+        ($($crate::debug!($val)),+,)
+    };
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

We’ve added a more efficient debug macro for replacing `dbg!()`. The original `dbg!()` has an issue where it calls `fd_write` for every line. However, since calling `fd_write` consumes 1Tgas, we quickly exhaust our gas supply, causing the program to crash with an out-of-gas error. To address this, we’ve introduced a `debug!()` macro that only calls `fd_write` once.
