### PR TITLE
feat(rs-sdk): add log and elog macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "seda-sdk-rs"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "hex",

--- a/libs/rs-sdk/sdk/Cargo.toml
+++ b/libs/rs-sdk/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-sdk-rs"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 edition = "2021"
 
 [dependencies]

--- a/libs/rs-sdk/sdk/src/log.rs
+++ b/libs/rs-sdk/sdk/src/log.rs
@@ -30,6 +30,7 @@ macro_rules! debug {
     ($expr:expr) => {
         match $expr {
             expr => {
+                use std::io::Write;
                 // Format the debug message
                 std::io::stderr().write_all(format!("[{}:{}] {} = {:#?}\n", file!(), line!(), stringify!($expr), &expr).as_bytes())?;
 

--- a/libs/rs-sdk/sdk/src/log.rs
+++ b/libs/rs-sdk/sdk/src/log.rs
@@ -43,18 +43,19 @@ macro_rules! debug {
     };
 }
 
-/// A logging macro that prints the value to stdout.
+/// A logging macro that prints the value to stdout, with a newline.
 ///
 /// This macro is a more gas-efficient alternative to regular println! statements.
-/// It evaluates the given expression and writes its display representation to standard output.
+/// It evaluates the given expression and writes its display representation to standard output,
+/// followed by a newline.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # use seda_sdk_rs::log;
 /// let value = 42;
-/// log!("{}\n", value);  // Prints: 42
-/// log!("The answer is: {}\n", value);  // Prints: The answer is: 42
+/// log!("{}", value);  // Prints: 42\n
+/// log!("The answer is: {}", value);  // Prints: The answer is: 42\n
 /// ```
 ///
 /// # Notes
@@ -64,23 +65,24 @@ macro_rules! debug {
 macro_rules! log {
     ($($arg:tt)*) => {{
         use std::io::Write;
-        let _ = std::io::stdout().write_all(format!($($arg)*).as_bytes());
+        let _ = std::io::stdout().write_all(format!("{}\n", format_args!($($arg)*)).as_bytes());
         ()
     }};
 }
 
-/// A logging macro that prints the value to stderr.
+/// A logging macro that prints the value to stderr, with a newline.
 ///
 /// This macro is a more gas-efficient alternative to regular eprintln! statements.
-/// It evaluates the given expression and writes its display representation to standard error.
+/// It evaluates the given expression and writes its display representation to standard error,
+/// followed by a newline.
 ///
 /// # Examples
 ///
 /// ```rust
 /// # use seda_sdk_rs::elog;
 /// let error_code = 404;
-/// elog!("{}\n", error_code);  // Prints: 404
-/// elog!("Error {}: Not Found\n", error_code);  // Prints: Error 404: Not Found
+/// elog!("{}", error_code);  // Prints: 404\n
+/// elog!("Error {}: Not Found", error_code);  // Prints: Error 404: Not Found\n
 /// ```
 ///
 /// # Notes
@@ -90,7 +92,7 @@ macro_rules! log {
 macro_rules! elog {
     ($($arg:tt)*) => {{
         use std::io::Write;
-        let _ = std::io::stderr().write_all(format!($($arg)*).as_bytes());
+        let _ = std::io::stderr().write_all(format!("{}\n", format_args!($($arg)*)).as_bytes());
         ()
     }};
 }

--- a/libs/rs-sdk/sdk/src/log.rs
+++ b/libs/rs-sdk/sdk/src/log.rs
@@ -42,3 +42,55 @@ macro_rules! debug {
         ($($crate::debug!($val)),+,)
     };
 }
+
+/// A logging macro that prints the value to stdout.
+///
+/// This macro is a more gas-efficient alternative to regular println! statements.
+/// It evaluates the given expression and writes its display representation to standard output.
+///
+/// # Examples
+///
+/// ```rust
+/// # use seda_sdk_rs::log;
+/// let value = 42;
+/// log!("{}\n", value);  // Prints: 42
+/// log!("The answer is: {}\n", value);  // Prints: The answer is: 42
+/// ```
+///
+/// # Notes
+///
+/// This macro requires that the expression's type implements the `Display` trait.
+#[macro_export]
+macro_rules! log {
+    ($($arg:tt)*) => {{
+        use std::io::Write;
+        let _ = std::io::stdout().write_all(format!($($arg)*).as_bytes());
+        ()
+    }};
+}
+
+/// A logging macro that prints the value to stderr.
+///
+/// This macro is a more gas-efficient alternative to regular eprintln! statements.
+/// It evaluates the given expression and writes its display representation to standard error.
+///
+/// # Examples
+///
+/// ```rust
+/// # use seda_sdk_rs::elog;
+/// let error_code = 404;
+/// elog!("{}\n", error_code);  // Prints: 404
+/// elog!("Error {}: Not Found\n", error_code);  // Prints: Error 404: Not Found
+/// ```
+///
+/// # Notes
+///
+/// This macro requires that the expression's type implements the `Display` trait.
+#[macro_export]
+macro_rules! elog {
+    ($($arg:tt)*) => {{
+        use std::io::Write;
+        let _ = std::io::stderr().write_all(format!($($arg)*).as_bytes());
+        ()
+    }};
+}


### PR DESCRIPTION
## Motivation

Added more gas-efficient logging macros as alternatives to standard print macros. Also fixed missing `Write` trait import in debug macro for better developer experience.

## Explanation of Changes

- Added `log!` and `elog!` macros using `write_all` for better gas efficiency
- Added `use std::io::Write` in debug macro to avoid requiring manual import
- Added documentation and examples for all macros

## Testing

Run the following to verify macros work:
```bash
cargo test -p seda-sdk-rs -- --nocapture
```

## Related PRs and Issues

N/A