### PR TITLE
feat(vm): use uwasi instead of wasmer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "@seda-protocol/utils": "^1.3.0",
         "@seda-protocol/wasm-metering-ts": "^2.0.0",
         "@types/node-gzip": "^1.1.1",
-        "@wasmer/wasi": "^1.2.2",
         "as-bignum": "^0.3.1",
         "big.js": "^6.2.1",
         "commander": "^11.0.0",
@@ -26,6 +25,7 @@
         "protobufjs": "7.2.5",
         "true-myth": "^8.0.1",
         "tslib": "^2.3.0",
+        "uwasi": "^1.4.1",
         "valibot": "^0.42.1",
         "visitor-as": "0.11.4",
       },
@@ -540,8 +540,6 @@
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
-
-    "@wasmer/wasi": ["@wasmer/wasi@1.2.2", "", {}, "sha512-39ZB3gefOVhBmkhf7Ta79RRSV/emIV8LhdvcWhP/MOZEjMmtzoZWMzt7phdKj8CUXOze+AwbvGK60lKaKldn1w=="],
 
     "@yarnpkg/lockfile": ["@yarnpkg/lockfile@1.1.0", "", {}, "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="],
 
@@ -1270,6 +1268,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.1.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uwasi": ["uwasi@1.4.1", "", {}, "sha512-QOT8tBsSwG7dm99Ry4X2gqsEEq4B6Q3eMSyazMQw7fd6XwBKPvBnxgpAksDRLZBMIp+F1wChhKPon20HQK6i0Q=="],
 
     "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
 

--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "1.0.0-rc.6",
+	"version": "1.0.0-rc.7",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",
@@ -20,7 +20,7 @@
 		"@cosmjs/tendermint-rpc": "^0.32.4",
 		"@seda-protocol/proto-messages": "1.0.0-rc.1",
 		"@seda-protocol/utils": "^1.3.0",
-		"@seda-protocol/vm": "^1.0.4",
+		"@seda-protocol/vm": "^1.0.5",
 		"big.js": "^6.2.1",
 		"dotenv": "^16.3.1",
 		"node-fetch": "^3.3.2",

--- a/libs/vm/package.json
+++ b/libs/vm/package.json
@@ -1,10 +1,10 @@
 {
 	"name": "@seda-protocol/vm",
 	"type": "module",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"dependencies": {
 		"@seda-protocol/wasm-metering-ts": "^2.0.0",
-		"@wasmer/wasi": "^1.2.2",
+		"uwasi": "^1.4.1",
 		"true-myth": "^7.3.0",
 		"@noble/secp256k1": "2.1.0",
 		"@noble/hashes": "1.4.0",

--- a/libs/wasm-integration-tests/tests/universal/test-vm.test.ts
+++ b/libs/wasm-integration-tests/tests/universal/test-vm.test.ts
@@ -172,7 +172,7 @@ describe("test-vm", () => {
 			true,
 		);
 
-		expect(result.stderr).toInclude("stream did not contain valid UTF-8`");
+		expect(result.stderr).toInclude("stream did not contain valid UTF-8");
 	});
 
 	it("stdout_non_utf8", async () => {
@@ -194,6 +194,6 @@ describe("test-vm", () => {
 			true,
 		);
 
-		expect(result.stderr).toInclude("stream did not contain valid UTF-8`");
+		expect(result.stderr).toInclude("stream did not contain valid UTF-8");
 	});
 });

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"@seda-protocol/utils": "^1.3.0",
 		"@seda-protocol/wasm-metering-ts": "^2.0.0",
 		"@types/node-gzip": "^1.1.1",
-		"@wasmer/wasi": "^1.2.2",
+		"uwasi": "^1.4.1",
 		"as-bignum": "^0.3.1",
 		"big.js": "^6.2.1",
 		"commander": "^11.0.0",


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

There was a memory leak in the `@wasmer/wasi` package. This package used native code to implement all WASI handlers. Only this was slowly increasing our memory usage. We chose a more lightweight option implemented in JavaScript which shows a lower memory footprint.

## Explanation of Changes

Replace Wasmer with uWasi

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

All tests passes (`bun run test`)
