### PR TITLE
Do not sent empty bodies in HTTP requests

### DIFF
--- a/libs/vm/src/data-request-vm-adapter.ts
+++ b/libs/vm/src/data-request-vm-adapter.ts
@@ -83,9 +83,7 @@ export default class DataRequestVmAdapter implements VmAdapter {
 				signal: AbortSignal.timeout(this.timeout),
 				method: action.options.method.toUpperCase(),
 				headers: action.options.headers,
-				body: action.options.body
-					? Buffer.from(action.options.body)
-					: undefined,
+				body: getBody(action),
 			});
 
 			if (!response.body) throw new VmError("HTTP Body was already consumed");
@@ -121,4 +119,18 @@ export default class DataRequestVmAdapter implements VmAdapter {
 			);
 		}
 	}
+}
+
+function getBody(action: HttpFetchAction) {
+	if (!action.options.body) {
+		return undefined;
+	}
+
+	const body = Buffer.from(action.options.body);
+	// If the body is empty, we don't need to send it
+	if (body.length === 0) {
+		return undefined;
+	}
+
+	return body;
 }


### PR DESCRIPTION
## Motivation

Prevent issues where an emtpy body gets serialised as `[]`, which then becomes a body.

## Explanation of Changes

N.A.

## Testing

Tests pass and the data proxy flow works for get requests.

## Related PRs and Issues

N.A.
