### PR TITLE
Report insufficient proxy fee

### DIFF
--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "1.0.0-rc.11",
+	"version": "1.0.0-rc.12",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",
@@ -20,7 +20,7 @@
 		"@cosmjs/tendermint-rpc": "^0.32.4",
 		"@seda-protocol/proto-messages": "1.0.0-rc.1",
 		"@seda-protocol/utils": "^1.3.0",
-		"@seda-protocol/vm": "^1.0.8",
+		"@seda-protocol/vm": "^1.0.9",
 		"big.js": "^6.2.1",
 		"dotenv": "^16.3.1",
 		"node-fetch": "^3.3.2",

--- a/libs/vm/package.json
+++ b/libs/vm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/vm",
 	"type": "module",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"dependencies": {
 		"@seda-protocol/wasm-metering-ts": "^2.0.0",
 		"uwasi": "^1.4.1",

--- a/libs/vm/src/errors.ts
+++ b/libs/vm/src/errors.ts
@@ -1,6 +1,8 @@
 export enum VmErrorType {
+	OutOfGas = "OutOfGas",
 	HttpFetchTimeout = "HttpFetchTimeout",
 	HttpFetchGlobalTimeout = "HttpFetchGlobalTimeout",
+	InsufficientDataProxyFee = "InsufficientDataProxyFee",
 	Unknown = "Unknown",
 }
 

--- a/libs/vm/src/metering.ts
+++ b/libs/vm/src/metering.ts
@@ -1,5 +1,5 @@
 import { Maybe, Result, type Unit } from "true-myth";
-import { VmError } from "./errors";
+import { VmError, VmErrorType } from "./errors";
 
 const GAS_MULTIPLIER_EXEC = 15n;
 const GAS_MULTIPLIER_TALLY = 150n;
@@ -102,7 +102,7 @@ export class GasMeter {
 	 * Since it's possible to have 0 points remaining without being out of gas,
 	 * we use a result error to indicate if the instance is out of gas.
 	 */
-	private getRemainingPoints(): Result<bigint, typeof OUT_OF_GAS_MESSAGE> {
+	getRemainingPoints(): Result<bigint, typeof OUT_OF_GAS_MESSAGE> {
 		// Since we're already using gas before the instance is set (such as the startup gas)
 		// we use the remaining points as they are on the gas meter.
 		// Once the instance is set we set its remaining points to the gas meter remaining points,
@@ -160,18 +160,24 @@ export class GasMeter {
 			this.pointsRemaining -= gasCost;
 
 			if (this.pointsRemaining < 0n) {
-				throw new VmError(OUT_OF_GAS_MESSAGE);
+				throw new VmError(OUT_OF_GAS_MESSAGE, {
+					type: VmErrorType.OutOfGas,
+				});
 			}
 			return;
 		}
 
 		const remainingPoints = this.getRemainingPoints();
 		if (remainingPoints.isErr) {
-			throw new VmError(OUT_OF_GAS_MESSAGE);
+			throw new VmError(OUT_OF_GAS_MESSAGE, {
+				type: VmErrorType.OutOfGas,
+			});
 		}
 
 		if (remainingPoints.value < gasCost) {
-			throw new VmError(OUT_OF_GAS_MESSAGE);
+			throw new VmError(OUT_OF_GAS_MESSAGE, {
+				type: VmErrorType.OutOfGas,
+			});
 		}
 
 		const newRemainingPoints = remainingPoints.value - gasCost;


### PR DESCRIPTION
## Motivation

Provide clear feedback to the user why their Oracle Program failed and abort the process as expected.

## Explanation of Changes

We now check for the async calls whether the error was an `OutOfGas` or `InsufficientDataProxyFee` error and rethrow accordingly. Without this the program would continue and try to parse a (proxy)HttpFetchResponse from the 0 bytes we sent back.

## Testing

Ran in a local overlay on planet: https://planet.test.explorer.seda.xyz/data-requests/8323daa061f8513753c19dd9a815aa06434b94afc9dc3c166e81a3a35422ddd0/32842

## Related PRs and Issues

Overlay PR will follow shortly :) 
