### PR TITLE
Check DR attribute limits before posting

### DIFF
--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "1.0.0-rc.12",
+	"version": "1.0.0-rc.13",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",

--- a/libs/dev-tools/src/lib/services/dr/create-dr-input.ts
+++ b/libs/dev-tools/src/lib/services/dr/create-dr-input.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert";
+import type { DrConfig } from "../get-dr-config";
 import {
 	type ConsensusFilter,
 	encodeConsensusFilter,
@@ -9,6 +11,16 @@ const DEFAULT_EXEC_GAS_LIMIT = 300_000_000_000_000;
 const DEFAULT_TALLY_GAS_LIMIT = 50_000_000_000_000;
 const DEFAULT_GAS_PRICE = 2_000n;
 const DEFAULT_MEMO = new Uint8Array([]);
+
+const defaultDrConfig: DrConfig = {
+	dr_reveal_size_limit_in_bytes: 24_000,
+	exec_input_limit_in_bytes: 2_048,
+	tally_input_limit_in_bytes: 512,
+	consensus_filter_limit_in_bytes: 512,
+	memo_limit_in_bytes: 512,
+	payback_address_limit_in_bytes: 128,
+	seda_payload_limit_in_bytes: 512,
+};
 
 export type PostDataRequestInput = {
 	version?: string;
@@ -63,33 +75,70 @@ export type PostDataRequestInput = {
 
 	/**
 	 * Memo field for any data you want to attach to the Data Request
-	 * Will also be returned to the destination chain
+	 * Will also be returned to the destination chain.
 	 */
 	memo?: Uint8Array;
 };
 
 export type DataRequest = ReturnType<typeof createPostedDataRequest>;
 
-export function createPostedDataRequest(input: PostDataRequestInput) {
+/**
+ * Creates a Data Request object that can be posted to the Data Request API.
+ *
+ * @param input - The input object containing the Data Request details.
+ * @param drConfig - The Data Request configuration on the contract. Defaults to the default values.
+ * @returns The Data Request object as the contract expects it.
+ */
+export function createPostedDataRequest(
+	input: PostDataRequestInput,
+	drConfig = defaultDrConfig,
+) {
 	const version = input.version ?? DEFAULT_VERSION;
 
 	const exec_program_id = input.execProgramId;
+	assert(
+		isHexAddress(exec_program_id),
+		"execProgramId must be a valid hex of 64 characters",
+	);
+
+	assert(
+		input.execInputs.length <= drConfig.exec_input_limit_in_bytes,
+		`execInputs must be less than ${drConfig.exec_input_limit_in_bytes + 1} bytes, received ${input.execInputs.length}`,
+	);
 	const exec_inputs = base64Encode(input.execInputs);
 
 	const tally_program_id = input.tallyProgramId ?? input.execProgramId;
+	assert(
+		isHexAddress(tally_program_id),
+		"tallyProgramId must be a valid hex of 64 characters",
+	);
+
+	assert(
+		input.tallyInputs.length <= drConfig.tally_input_limit_in_bytes,
+		`tallyInputs must be less than ${drConfig.tally_input_limit_in_bytes + 1} bytes, received ${input.tallyInputs.length}`,
+	);
 	const tally_inputs = base64Encode(input.tallyInputs);
 
 	const replication_factor =
 		input.replicationFactor ?? DEFAULT_REPLICATION_FACTOR;
 
-	const consensus_filter = base64Encode(
-		encodeConsensusFilter(input.consensusOptions),
+	const consensFilterBytes = encodeConsensusFilter(input.consensusOptions);
+	assert(
+		consensFilterBytes.length <= drConfig.consensus_filter_limit_in_bytes,
+		`consensus_filter must be less than ${drConfig.consensus_filter_limit_in_bytes + 1} bytes, received ${consensFilterBytes.length}`,
 	);
+	const consensus_filter = base64Encode(consensFilterBytes);
 
 	const exec_gas_limit = input.execGasLimit ?? DEFAULT_EXEC_GAS_LIMIT;
 	const tally_gas_limit = input.tallyGasLimit ?? DEFAULT_TALLY_GAS_LIMIT;
 	const gas_price = (input.gasPrice ?? DEFAULT_GAS_PRICE).toString();
 
+	if (input.memo) {
+		assert(
+			input.memo.length <= drConfig.memo_limit_in_bytes,
+			`memo must be less than ${drConfig.memo_limit_in_bytes + 1} bytes, received ${input.memo.length}`,
+		);
+	}
 	const memo = base64Encode(input.memo ?? DEFAULT_MEMO);
 
 	return {
@@ -109,4 +158,8 @@ export function createPostedDataRequest(input: PostDataRequestInput) {
 
 function base64Encode(value: Uint8Array): string {
 	return Buffer.from(value).toString("base64");
+}
+
+function isHexAddress(address: string): boolean {
+	return !!address.match(/^[0-9a-fA-F]{64}$/);
 }

--- a/libs/dev-tools/src/lib/services/dr/post-data-request-bundle.ts
+++ b/libs/dev-tools/src/lib/services/dr/post-data-request-bundle.ts
@@ -2,6 +2,7 @@ import { calculateDrFunds } from "@dev-tools/services/dr/calculate-dr-funds";
 import { tryParseSync } from "@seda-protocol/utils";
 import * as v from "valibot";
 import type { GasOptions } from "../gas-options";
+import { getDrConfig } from "../get-dr-config";
 import { signAndSendTx } from "../sign-and-send-tx";
 import type { ISigner } from "../signer";
 import { createSigningClient } from "../signing-client";
@@ -27,11 +28,15 @@ export async function postDataRequestBundle(
 	}
 
 	const contract = signer.getCoreContractAddress();
+	const drConfig = await getDrConfig(sigingClientResult.value.client, signer);
+	if (drConfig.isErr) {
+		throw drConfig.error;
+	}
 
 	const { client: sigingClient, address } = sigingClientResult.value;
 
 	const messages = dataRequestInputs.map((dataRequestInput) => {
-		const postedDr = createPostedDataRequest(dataRequestInput);
+		const postedDr = createPostedDataRequest(dataRequestInput, drConfig.value);
 		return {
 			typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
 			value: {

--- a/libs/dev-tools/src/lib/services/dr/post-data-request.ts
+++ b/libs/dev-tools/src/lib/services/dr/post-data-request.ts
@@ -1,6 +1,7 @@
 import { tryParseSync } from "@seda-protocol/utils";
 import * as v from "valibot";
 import type { GasOptions } from "../gas-options";
+import { getDrConfig } from "../get-dr-config";
 import { signAndSendTx } from "../sign-and-send-tx";
 import type { ISigner } from "../signer";
 import { createSigningClient } from "../signing-client";
@@ -33,10 +34,14 @@ export async function postDataRequest(
 	}
 
 	const contract = signer.getCoreContractAddress();
+	const drConfig = await getDrConfig(sigingClientResult.value.client, signer);
+	if (drConfig.isErr) {
+		throw drConfig.error;
+	}
 
 	const { client: sigingClient, address } = sigingClientResult.value;
 
-	const postedDr = createPostedDataRequest(dataRequestInput);
+	const postedDr = createPostedDataRequest(dataRequestInput, drConfig.value);
 
 	const message = {
 		typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",

--- a/libs/dev-tools/src/lib/services/get-dr-config.ts
+++ b/libs/dev-tools/src/lib/services/get-dr-config.ts
@@ -1,0 +1,35 @@
+import type { SigningCosmWasmClient } from "@cosmjs/cosmwasm-stargate";
+import { tryAsync, tryParseSync } from "@seda-protocol/utils";
+import { Result, ResultNS } from "true-myth";
+import * as v from "valibot";
+import type { ISigner } from "./signer";
+
+const DrConfigSchema = v.object({
+	dr_reveal_size_limit_in_bytes: v.number(),
+	exec_input_limit_in_bytes: v.number(),
+	tally_input_limit_in_bytes: v.number(),
+	consensus_filter_limit_in_bytes: v.number(),
+	memo_limit_in_bytes: v.number(),
+	payback_address_limit_in_bytes: v.number(),
+	seda_payload_limit_in_bytes: v.number(),
+});
+
+export type DrConfig = v.InferOutput<typeof DrConfigSchema>;
+
+export async function getDrConfig(
+	signingClient: SigningCosmWasmClient,
+	signer: ISigner,
+): Promise<Result<DrConfig, unknown>> {
+	const contract = signer.getCoreContractAddress();
+
+	const config = await tryAsync(async () =>
+		signingClient.queryContractSmart(contract, {
+			get_dr_config: {},
+		}),
+	);
+	if (config.isErr) {
+		return Result.err(config.error);
+	}
+
+	return tryParseSync(DrConfigSchema, config.value);
+}


### PR DESCRIPTION
## Motivation

Now that we're imposing limits on the DR fields it's nice for developers to see they're hitting the limits before trying to submit the DR.

## Explanation of Changes

We first fetch the DR config from the contract before converting the inputs.

## Testing

Tested in the DR playground by locally linking to the dev-tools package.

## Related PRs and Issues

N.A.
