### PR TITLE
feat(dev-tools): support signer with multiple addresses

### DIFF
--- a/libs/dev-tools/src/lib/services/config.ts
+++ b/libs/dev-tools/src/lib/services/config.ts
@@ -47,10 +47,10 @@ function getFromOptsOrEnvOrFail<
 
 function getFromOptsOrEnv<
 	K extends string,
-	A extends Record<K, string | undefined>,
+	A extends Record<K, string | number | undefined>,
 >(key: K, opts: Partial<A>, envKey: string): Maybe<string> {
 	return Maybe.of(opts[key]).mapOrElse(
 		() => getEnv(envKey),
-		(t) => Maybe.just(t as string),
+		(t) => Maybe.just(String(t)),
 	);
 }

--- a/libs/dev-tools/src/lib/services/signer.ts
+++ b/libs/dev-tools/src/lib/services/signer.ts
@@ -1,4 +1,6 @@
+import { stringToPath } from "@cosmjs/crypto";
 import {
+	AccountData,
 	DirectSecp256k1HdWallet,
 	type OfflineSigner,
 } from "@cosmjs/proto-signing";
@@ -11,6 +13,9 @@ import {
 } from "./config";
 
 const BECH32_ADDRESS_PREFIX = "seda";
+// DirectSecp256k1HdWallet uses BIP-44 paths with format m/44'/118'/account'/0/address
+// where account and address indices start at 0
+const DEFAULT_HD_PATH_WITHOUT_INDEX = "m/44'/118'/0'/0/";
 
 export interface ISigner {
 	getEndpoint: () => string;
@@ -19,25 +24,38 @@ export interface ISigner {
 	getCoreContractAddress: () => string;
 }
 
+const DEFAULT_ADDRESS_INDEX = 0;
+
 export class Signer implements ISigner {
 	private constructor(
 		private endpoint: string,
 		private signer: DirectSecp256k1HdWallet,
-		private address: string,
+		private addresses: string[],
 		private coreContractAddress: string,
+		private addressIndex: number,
 	) {}
 
 	/**
 	 * Attempts to initialise a signer by parsing environment variables for config that is not
 	 * provided directly.
 	 *
+	 * @param opts - The configuration for the signer.
+	 * @param addressIndex - The index of the address to use. Defaults to 0.
 	 * @throws Error when initialising wallet or deriving address fails.
 	 */
-	static async fromPartial(opts: Partial<SigningConfig>): Promise<Signer> {
+	static async fromPartial(
+		opts: Partial<SigningConfig>,
+		addressIndex = DEFAULT_ADDRESS_INDEX,
+	): Promise<Signer> {
+		if (addressIndex < 0) {
+			throw Error("Address index must be greater than or equal to 0");
+		}
+
 		const config = buildSigningConfig(opts);
 
 		const wallet = await DirectSecp256k1HdWallet.fromMnemonic(config.mnemonic, {
 			prefix: BECH32_ADDRESS_PREFIX,
+			hdPaths: getHdPaths(addressIndex),
 		});
 
 		const contract = await resolveCoreContractAddress(config);
@@ -47,9 +65,9 @@ export class Signer implements ISigner {
 			throw Error("Address for given mnemonic does not exist");
 		}
 
-		const address = accounts[0].address;
+		const addresses = accounts.map((account) => account.address);
 
-		return new Signer(config.rpc, wallet, address, contract);
+		return new Signer(config.rpc, wallet, addresses, contract, addressIndex);
 	}
 
 	getSigner() {
@@ -57,7 +75,7 @@ export class Signer implements ISigner {
 	}
 
 	getAddress() {
-		return this.address;
+		return this.addresses[this.addressIndex];
 	}
 
 	getEndpoint() {
@@ -67,6 +85,23 @@ export class Signer implements ISigner {
 	getCoreContractAddress() {
 		return this.coreContractAddress;
 	}
+}
+
+/**
+ * Returns the HD paths required to derive the given address index.
+ *
+ * @param addressIndex - The index of the address to derive. Must be greater than or equal to 0.
+ * @returns The HD paths required to derive the given address index.
+ */
+function getHdPaths(addressIndex: number) {
+	// Passing undefined to the wallet constructor will use the default HD path
+	if (addressIndex <= 0) {
+		return undefined;
+	}
+
+	return Array.from({ length: addressIndex + 1 }, (_, i) =>
+		stringToPath(`${DEFAULT_HD_PATH_WITHOUT_INDEX}${i}`),
+	);
 }
 
 async function resolveCoreContractAddress(config: SigningConfig) {


### PR DESCRIPTION
## Motivation

Enable support for deriving multiple addresses from a single mnemonic in the SDK, allowing users to work with multiple wallets without needing separate seed phrases.

## Explanation of Changes

- Added `addressCount` parameter to `SigningConfig`
- Modified `DirectSecp256k1HdWallet` initialization to support multiple HD paths
- Updated environment variable handling for the new parameter

(Write your explanation here)

## Testing

🙄 

## Related PRs and Issues

N/A
