### PR TITLE
Hashmap limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://seda.xyz/">
-    <img width="90%" alt="seda-sdk" src="https://www.seda.xyz/images/footer/footer-image.png">
+    <img width="90%" alt="seda-chain" src="https://raw.githubusercontent.com/sedaprotocol/.github/refs/heads/main/images/banner.png">
   </a>
 </p>
 

--- a/libs/rs-sdk-integration-tests/src/main.rs
+++ b/libs/rs-sdk-integration-tests/src/main.rs
@@ -12,7 +12,9 @@ use infinite_loop::{test_infinite_loop, test_infinite_loop_http_fetch};
 use proxy_http::{test_generate_proxy_http_message, test_proxy_http_fetch};
 use random_get::test_random_get;
 use seda_sdk_rs::{bytes::ToBytes, process::Process};
-use tally::{test_tally_vm_reveals, test_tally_vm_reveals_filtered};
+use tally::{
+    test_tally_deterministic_hashmap, test_tally_hashmap, test_tally_vm_reveals, test_tally_vm_reveals_filtered,
+};
 use vm_tests::{test_tally_vm_http, test_tally_vm_mode};
 fn main() {
     let args = String::from_utf8(Process::get_inputs()).unwrap();
@@ -34,6 +36,8 @@ fn main() {
         "testInfiniteLoopHttpFetch" => test_infinite_loop_http_fetch(),
         "testRandomGet" => test_random_get(),
         "testPanic" => panic!("test panic"),
+        "testTallyHashMap" => test_tally_hashmap(),
+        "testTallyDeterministicHashMap" => test_tally_deterministic_hashmap(),
         _ => Process::error(&"No argument given".to_bytes()),
     }
 }

--- a/libs/rs-sdk-integration-tests/src/tally.rs
+++ b/libs/rs-sdk-integration-tests/src/tally.rs
@@ -1,4 +1,5 @@
-use seda_sdk_rs::{get_reveals, get_unfiltered_reveals, process::Process};
+use seda_sdk_rs::{get_reveals, get_unfiltered_reveals, hashmap::HashMap, process::Process};
+use std::collections::HashMap as StdHashMap;
 
 pub fn test_tally_vm_reveals() {
     let reveals = get_unfiltered_reveals();
@@ -16,6 +17,22 @@ pub fn test_tally_vm_reveals() {
 pub fn test_tally_vm_reveals_filtered() {
     let reveals = get_reveals().unwrap();
     let reveals_bytes = serde_json::to_vec(&reveals).unwrap();
+
+    Process::success(&reveals_bytes);
+}
+
+pub fn test_tally_hashmap() {
+    let mut map = StdHashMap::<String, String>::default();
+    map.insert("key".to_string(), "value".to_string());
+    let reveals_bytes = serde_json::to_vec(&map).unwrap();
+
+    Process::success(&reveals_bytes);
+}
+
+pub fn test_tally_deterministic_hashmap() {
+    let mut map = HashMap::<String, String>::default();
+    map.insert("key".to_string(), "value".to_string());
+    let reveals_bytes = serde_json::to_vec(&map).unwrap();
 
     Process::success(&reveals_bytes);
 }

--- a/libs/rs-sdk/README.md
+++ b/libs/rs-sdk/README.md
@@ -4,9 +4,25 @@ SDK for creating Oracle Programs on the SEDA chain.
 
 ## Caveats
 
-- println, eprint, dbg alternatives
-- Determinism
-- HashMap
+When writing Oracle Programs in Rust for SEDA, there are several important considerations to keep in mind:
+
+### Logging and Debugging
+
+The standard Rust logging macros like `println!`, `eprintln!`, and `dbg!` are not suitable for use in Oracle Programs as they consume large amounts of gas. Instead, we provide the `Console` module which offers gas-efficient alternatives:
+
+- `debug!` - `dbg!` alternative. Used for printing debug information to std err
+- `log!` - `println!` alternative. Used for logging to std out
+- `elog!` - `eprintln!` alternative. Used for logging to std err
+
+### Determinism and the Tally Phase
+
+While the execution phase of an Oracle Program has access to non-deterministic data, the tally phase of an Oracle Program must be deterministic. This means it produces the same output given the same input. When you or a library tries to access randomness the program will halt and exit with an error.
+
+The standard `HashMap` from `std::collections` can't be used without a custom hasher, as the default hasher relies on randomness for the initial seed. Instead try one of the following:
+
+- `BTreeMap` - For key-value storage with ordered keys
+- `Vec` with manual key lookups - For smaller datasets
+- Our provided `seda_sdk_rs::HashMap` - A wrapper around `std::collections::HashMap` with a deterministic hasher
 
 ## Example
 

--- a/libs/rs-sdk/README.md
+++ b/libs/rs-sdk/README.md
@@ -1,0 +1,52 @@
+# Rust SDK
+
+SDK for creating Oracle Programs on the SEDA chain.
+
+## Caveats
+
+- println, eprint, dbg alternatives
+- Determinism
+- HashMap
+
+## Example
+
+Below is an example of an Oracle Program that retrieves the name of a planet in the SWAPI database.
+
+```rs
+use seda_sdk_rs::{bytes::ToBytes, http::http_fetch, process::Process};
+use serde::Deserialize;
+
+// The JSON schema of the response we're expecting.
+#[derive(Deserialize)]
+struct SwPlanet {
+  name: String,
+}
+use seda_sdk_rs::{bytes::ToBytes, http::http_fetch, process::Process};
+
+#[seda_sdk_rs::oracle_program]
+impl SimplePriceFeed {
+  fn execute() {
+    let input = Process::get_inputs();
+
+    // HTTP Fetch to the SWAPI
+    let response = http_fetch(
+      format!("https://swapi.dev/api/planets/{}", String::from_utf8(input).unwrap()),
+      None,
+    );
+
+    if response.is_ok() {
+      // We need to parse the response Bytes as the expected JSON.
+      let data = serde_json::from_slice::<SwPlanet>(&response.bytes).unwrap();
+
+      // Exits the program (with an exit code of 0) and sets the Data Request result to the planet name
+      Process::success(&format!("{}", data.name).to_bytes());
+    } else {
+      Process::error(&"Error while fetching".to_bytes());
+    }
+  }
+
+  fn tally() {
+    Process::error(&"Tally was not implemented (yet)".to_bytes());
+  }
+}
+```

--- a/libs/rs-sdk/sdk/Cargo.toml
+++ b/libs/rs-sdk/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seda-sdk-rs"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 edition = "2021"
 
 [dependencies]

--- a/libs/rs-sdk/sdk/src/hashmap.rs
+++ b/libs/rs-sdk/sdk/src/hashmap.rs
@@ -1,0 +1,28 @@
+use std::{
+    collections::HashMap as StdHashMap,
+    hash::{BuildHasher, DefaultHasher},
+};
+
+pub struct DeterministicHasher {}
+
+impl DeterministicHasher {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for DeterministicHasher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BuildHasher for DeterministicHasher {
+    type Hasher = DefaultHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        DefaultHasher::new()
+    }
+}
+
+pub type HashMap<K, V> = StdHashMap<K, V, DeterministicHasher>;

--- a/libs/rs-sdk/sdk/src/lib.rs
+++ b/libs/rs-sdk/sdk/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bytes;
 pub mod errors;
+pub mod hashmap;
 pub mod http;
 pub mod keccak256;
 pub mod log;

--- a/libs/vm/package.json
+++ b/libs/vm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/vm",
 	"type": "module",
-	"version": "1.0.9",
+	"version": "1.0.10",
 	"dependencies": {
 		"@seda-protocol/wasm-metering-ts": "^2.0.0",
 		"uwasi": "^1.4.1",

--- a/libs/vm/src/imports/import-utils.ts
+++ b/libs/vm/src/imports/import-utils.ts
@@ -1,11 +1,12 @@
 import { VmError } from "../errors";
 
 export function extractFunctionFromImportValue(
+	name: string,
 	input: WebAssembly.ImportValue,
 	// biome-ignore lint/complexity/noBannedTypes: ImportValues are of the generic type Function
 ): Function {
 	if (typeof input !== "function") {
-		throw new VmError("import was not a function");
+		throw new VmError(`import ${name} was not a function`);
 	}
 
 	return input;

--- a/libs/vm/src/imports/wasi/args_get.ts
+++ b/libs/vm/src/imports/wasi/args_get.ts
@@ -17,7 +17,7 @@ export function args_sizes_get(
 		CallType.ArgsSizesGet,
 		BigInt(getArgsBytesLength(vmCallData.args)),
 	);
-	const func = extractFunctionFromImportValue(importValue);
+	const func = extractFunctionFromImportValue("args_sizes_get", importValue);
 	return func(argc, argv_buf_size);
 }
 
@@ -32,6 +32,6 @@ export function args_get(
 		CallType.ArgsGet,
 		BigInt(getArgsBytesLength(vmCallData.args)),
 	);
-	const func = extractFunctionFromImportValue(importValue);
+	const func = extractFunctionFromImportValue("args_get", importValue);
 	return func(argv, argv_buf);
 }

--- a/libs/vm/src/imports/wasi/environ_get.ts
+++ b/libs/vm/src/imports/wasi/environ_get.ts
@@ -20,7 +20,7 @@ export function environ_get(
 		CallType.EnvironGet,
 		BigInt(getEnvBytesLength(vmCallData.envs)),
 	);
-	const func = extractFunctionFromImportValue(importValue);
+	const func = extractFunctionFromImportValue("environ_get", importValue);
 	return func(environ, environ_buf);
 }
 
@@ -35,6 +35,6 @@ export function environ_sizes_get(
 		CallType.EnvironSizesGet,
 		BigInt(getEnvBytesLength(vmCallData.envs)),
 	);
-	const func = extractFunctionFromImportValue(importValue);
+	const func = extractFunctionFromImportValue("environ_sizes_get", importValue);
 	return func(environc, environ_buf_size);
 }

--- a/libs/vm/src/imports/wasi/fd_write.ts
+++ b/libs/vm/src/imports/wasi/fd_write.ts
@@ -10,6 +10,6 @@ export function fd_write(
 	nwritten: number,
 ) {
 	gasMeter.applyGasCost(CallType.FdWrite, BigInt(iovs_len));
-	const func = extractFunctionFromImportValue(importValue);
+	const func = extractFunctionFromImportValue("fd_write", importValue);
 	return func(fd, iovs, iovs_len, nwritten);
 }

--- a/libs/vm/src/imports/wasi/random_get.ts
+++ b/libs/vm/src/imports/wasi/random_get.ts
@@ -8,6 +8,6 @@ export function random_get(
 	bufLen: number,
 ) {
 	gasMeter.applyGasCost(CallType.RandomGet, BigInt(bufLen));
-	const func = extractFunctionFromImportValue(importValue);
+	const func = extractFunctionFromImportValue("random_get", importValue);
 	return func(buf, bufLen);
 }

--- a/libs/wasm-integration-tests/tests/rs-sdk/tally-determinism.test.ts
+++ b/libs/wasm-integration-tests/tests/rs-sdk/tally-determinism.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { testOracleProgramTally } from "@seda/dev-tools";
+import { oracleProgram } from "./oracle-program";
+
+describe("rs-sdk:tally-determinism", () => {
+	it("should panic when using the default hashmap", async () => {
+		const result = await testOracleProgramTally(
+			oracleProgram,
+			Buffer.from("testTallyHashMap"),
+			[],
+			50_000_000_000_000n,
+		);
+
+		expect(result.exitCode).toBe(1);
+		// Sadly we can't know that it was HashMap that triggered the `random_get` import error
+		expect(result.stderr).toContain("import random_get was not a function");
+	});
+
+	it("should not panic when using our deterministic hashmap", async () => {
+		const result = await testOracleProgramTally(
+			oracleProgram,
+			Buffer.from("testTallyDeterministicHashMap"),
+			[],
+			50_000_000_000_000n,
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.result).toEqual(Buffer.from('{"key":"value"}'));
+	});
+});


### PR DESCRIPTION
## Motivation

Provide alternatives to developers for `HashMap` in the tally phase.

## Explanation of Changes

Wrap the default `HashMap` with a custom hash builder that does not rely on a random seed. No idea if this is the best way to do this though 😬 

Updated the VM to make any wasi import errors more explicit. 

## Testing

Added tests that confirm the regular HashMap fails and our wrapper works.

## Related PRs and Issues

Closes: #175 
