### PR TITLE
Fix Typos in Comments for Staking and ABCI Types

### DIFF
--- a/libs/proto-messages/gen/cosmos/staking/v1beta1/staking.ts
+++ b/libs/proto-messages/gen/cosmos/staking/v1beta1/staking.ts
@@ -202,7 +202,7 @@ export interface Validator {
   minSelfDelegation: string;
   /** strictly positive if this validator's unbonding has been stopped by external modules */
   unbondingOnHoldRefCount: bigint;
-  /** list of unbonding ids, each uniquely identifing an unbonding of this validator */
+  /** list of unbonding ids, each uniquely identifying an unbonding of this validator */
   unbondingIds: bigint[];
 }
 

--- a/libs/proto-messages/gen/tendermint/abci/types.ts
+++ b/libs/proto-messages/gen/tendermint/abci/types.ts
@@ -294,7 +294,7 @@ export interface ResponseCheckTx {
   priority: bigint;
   /**
    * mempool_error is set by CometBFT.
-   * ABCI applictions creating a ResponseCheckTX should not set mempool_error.
+   * ABCI applications creating a ResponseCheckTX should not set mempool_error.
    */
   mempoolError: string;
 }


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the TypeScript documentation comments for the staking and ABCI types. Specifically:
- Fixed the spelling of "identifying" in the staking validator interface comment.
- Fixed the spelling of "applications" in the ABCI ResponseCheckTx interface comment.

No functional code changes were made; these are documentation improvements only.

