### PR TITLE
feat(rs-sdk): don't reveal path info in panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1.0"
+ctor = "0.4"
 hex = "0.4"
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/libs/rs-sdk/README.md
+++ b/libs/rs-sdk/README.md
@@ -14,6 +14,12 @@ The standard Rust logging macros like `println!`, `eprintln!`, and `dbg!` are no
 - `log!` - `println!` alternative. Used for logging to std out
 - `elog!` - `eprintln!` alternative. Used for logging to std err
 
+### Stripped Panic Messages
+
+By default when SDK is imported and used it turns on the `hide-panic-paths` feature. This feature sets a panic hook to remove location details as to not show the filepath of the person who compiled the Oracle Program. It attempts to retain the panic message details, but if it cannot it instead `elogs!("<panic>");`.
+
+If you run into the above and wish to see the full message, note that it will print the path of where the panic occurred(downloaded crates or your oracle program), you can disable this feature. That can be done via your `Cargo.toml` and doing `seda-sdk-rs = { git = "https://github.com/sedaprotocol/seda-sdk", tag/version/branch = "some_qualifier", default-features = false }`.
+
 ### Determinism and the Tally Phase
 
 While the execution phase of an Oracle Program has access to non-deterministic data, the tally phase of an Oracle Program must be deterministic. This means it produces the same output given the same input. When you or a library tries to access randomness the program will halt and exit with an error.

--- a/libs/rs-sdk/sdk/Cargo.toml
+++ b/libs/rs-sdk/sdk/Cargo.toml
@@ -3,10 +3,15 @@ name = "seda-sdk-rs"
 version = "1.0.0-rc.4"
 edition = "2021"
 
+[features]
+default = ["hide-panic-paths"]
+hide-panic-paths = ["dep:ctor"]
+
 [dependencies]
-anyhow = { workspace = true }
-hex = { workspace = true }
+anyhow.workspace = true
+ctor = { workspace = true, optional = true }
+hex.workspace = true
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-thiserror = { workspace = true }
+serde_json.workspace = true
+thiserror.workspace = true
 seda-sdk-macros.workspace = true

--- a/libs/rs-sdk/sdk/src/lib.rs
+++ b/libs/rs-sdk/sdk/src/lib.rs
@@ -21,3 +21,24 @@ pub use secp256k1::secp256k1_verify;
 pub use tally::*;
 
 pub use seda_sdk_macros::oracle_program;
+
+#[cfg(feature = "hide-panic-paths")]
+/// A function run before the main function, via `ctor::ctor`, to set a sanitized panic hook.
+/// This hook takes the `std::panic::PanicInfo` and attempts to downcast the payload to a string.
+/// If unsuccessful, it defaults to printing "<panic>".
+/// It then gracefully aborts the process.
+#[ctor::ctor]
+fn init_sanitized_panic_hook() {
+    std::panic::set_hook(Box::new(|info| {
+        // print only the panic message, never the location
+        let msg = info
+            .payload()
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| info.payload().downcast_ref::<String>().map(|s| s.as_str()))
+            .unwrap_or("<panic>");
+        elog!("panicked: {msg}");
+        elog!("note: you can disable the `hide-panic-paths` feature to see the full panic message, including the file and line number.");
+        std::process::abort();
+    }));
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So that panics in rust don't reveal the user's paths.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Uses `ctor` to register the function to run before main.
- Downcasts the panic, `std::panic::PanicHookInfo`, payload to a String if possible otherwise just puts the message `<panic>`. The panic message if it can't be downcasted to a string is not very helpful. Not sure if we could do any better though.

> ![NOTE] This does effect panic messages that would occur from any crate.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

What it looked like before with a panic in the wasm rust code itself:
![image](https://github.com/user-attachments/assets/faeaee0d-d431-4540-acb4-8645ac6b83bc)

A panic in the wasm rust code itself after:
![image](https://github.com/user-attachments/assets/20c1f8c6-5b96-4385-a0ee-d9a8d2b5397b)

What it looked like before with a panic from the sdk bubbling up:
![image](https://github.com/user-attachments/assets/ed27ccd6-e7af-4e53-ae55-4167b52c6392)

A panic from the sdk bubbling up after:
![image](https://github.com/user-attachments/assets/b0329cfe-dc74-4a95-bc68-8fc955179f0a)

## Related PRs and Issues

Closes #182.
