### PR TITLE
Feat/cache crash

### DIFF
--- a/libs/vm/package.json
+++ b/libs/vm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/vm",
 	"type": "module",
-	"version": "1.0.12",
+	"version": "1.0.13",
 	"dependencies": {
 		"@seda-protocol/wasm-metering-ts": "^2.0.1",
 		"uwasi": "^1.4.1",

--- a/libs/vm/src/services/wasm-module.ts
+++ b/libs/vm/src/services/wasm-module.ts
@@ -1,6 +1,6 @@
 import { randomFillSync } from "node:crypto";
 import { existsSync, read } from "node:fs";
-import { readFile, writeFile, access, constants } from "node:fs/promises";
+import { constants, access, readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { tryAsync, trySync } from "@seda-protocol/utils";
 // @ts-ignore


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

There were cases where reading from the cache failed due access permissions. This makes sure that we can read the file and if not we just re-compile the binary in memory.
