### PR TITLE
docs: deny missing docs, fix macros + generic fn

### DIFF
--- a/libs/rs-sdk/README.md
+++ b/libs/rs-sdk/README.md
@@ -1,4 +1,5 @@
 # Rust SDK
+[![](https://img.shields.io/crates/v/seda-sdk-rs.svg)](https://crates.io/crates/seda-sdk-rs) [![](https://docs.rs/seda-sdk-rs/badge.svg)](https://docs.rs/seda-sdk-rs)
 
 SDK for creating Oracle Programs on the SEDA chain.
 

--- a/libs/rs-sdk/sdk/Cargo.toml
+++ b/libs/rs-sdk/sdk/Cargo.toml
@@ -15,4 +15,5 @@ hex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
+# TODO: macros feature to optionally enable macro usage
 seda-sdk-macros.workspace = true

--- a/libs/rs-sdk/sdk/src/bytes.rs
+++ b/libs/rs-sdk/sdk/src/bytes.rs
@@ -1,20 +1,39 @@
+//! Module for handling byte arrays in a oracle program compatible way.
+//!
+//! Creating a standardized way to handle byte arrays is important for
+//! oracle programs, as they are expected to return promises in a specific
+//! format.
+//!
+//! This module provides a [`Bytes`] type that wraps a vector of bytes
+//! and implements the [`ToBytes`] and [`FromBytes`] traits for various types.
+
 use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 
 use crate::{errors, errors::Result};
 
+/// A wrapper around a vector of bytes that provides convenience methods for
+/// the format that oracle promises are expected to be in.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Bytes(Vec<u8>);
 
 impl Bytes {
+    /// Get the inner vector of bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seda_sdk_rs::bytes::{Bytes, ToBytes};
+    /// let bytes: Bytes = "Hello, world!".to_bytes();
+    /// let inner: Vec<u8> = bytes.eject();
+    /// assert_eq!(inner, b"Hello, world!");
+    /// ```
     pub fn eject(self) -> Vec<u8> {
         self.0
     }
 }
 
-/// We implement Deref over the Bytes type allowing us to avoid a clone for
-/// `FromBytes`.
 impl Deref for Bytes {
     type Target = [u8];
 
@@ -23,7 +42,21 @@ impl Deref for Bytes {
     }
 }
 
+/// A trait for types that can be converted to the [`Bytes`] type.
+///
+/// This trait is implemented for various types such as `Vec<u8>`, `String`, `&str`, and primitive types like `u8`, `i32`, etc.
+///
+/// Additionally it supports an JSON serializable type via the [`serde`] and [`serde_json`] crates.
 pub trait ToBytes {
+    /// Converts the implementing type to a [`Bytes`] instance.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seda_sdk_rs::bytes::{Bytes, ToBytes};
+    /// let bytes: Bytes = "Hello, world!".to_bytes();
+    /// assert_eq!(bytes.eject(), b"Hello, world!");
+    /// ```
     fn to_bytes(self) -> Bytes;
 }
 
@@ -57,20 +90,61 @@ impl ToBytes for bool {
     }
 }
 
-/// For functions that return an `()` to be converted to a
-/// [crate::PromiseStatus]
 impl ToBytes for () {
     fn to_bytes(self) -> Bytes {
         Bytes::default()
     }
 }
 
+/// A trait to convert [`Bytes`] into a specific type.
+///
+/// This trait is implemented for various types such as `Vec<u8>`, `String`, `&str`, and primitive types like `u8`, `i32`, etc.
+///
+/// Additionally it supports an JSON deserializable type via the [`serde`] and [`serde_json`] crates.
 pub trait FromBytes
 where
     Self: Sized,
 {
+    /// A way to convert the [`Bytes`] into the implementing type without consuming the original bytes.
+    ///
+    /// # Errors
+    ///
+    /// There are several reasons why this conversion might fail returning an [`errors::SDKError`]:
+    ///
+    /// - [`errors::SDKError::FromUtf8Error`] if the bytes are not valid UTF-8.
+    /// - [`errors::SDKError::NumBytesConversion`] if the bytes are not of the expected length for the type of number primitive.
+    /// - [`errors::SDKError::InvalidValue`] if the bytes do not represent a valid value for the type.
+    /// - [`errors::SDKError::Serde`] if the bytes cannot be deserialized into the type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seda_sdk_rs::bytes::{FromBytes, ToBytes};
+    /// let bytes = "Hello, world!".to_bytes();
+    /// let string: String = String::from_bytes(&bytes).expect("Should be valid UTF-8");
+    /// assert_eq!(string, "Hello, world!");
+    /// ```
     fn from_bytes(bytes: &[u8]) -> Result<Self>;
 
+    /// A way to convert the [`Bytes`] into the implementing type and consume the original bytes.
+    ///
+    /// # Errors
+    ///
+    /// There are several reasons why this conversion might fail returning an [`errors::SDKError`]:
+    ///
+    /// - [`errors::SDKError::FromUtf8Error`] if the bytes are not valid UTF-8.
+    /// - [`errors::SDKError::NumBytesConversion`] if the bytes are not of the expected length for the type of number primitive.
+    /// - [`errors::SDKError::InvalidValue`] if the bytes do not represent a valid value for the type.
+    /// - [`errors::SDKError::Serde`] if the bytes cannot be deserialized into the type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seda_sdk_rs::bytes::{FromBytes, ToBytes};
+    /// let bytes = "Hello, world!".to_bytes();
+    /// let string: String = String::from_bytes_vec(bytes.eject()).expect("Should be valid UTF-8");
+    /// assert_eq!(string, "Hello, world!");
+    /// ```
     fn from_bytes_vec(bytes: Vec<u8>) -> Result<Self>;
 }
 
@@ -133,21 +207,48 @@ macro_rules! bytes_impls_le_bytes {
     };
 }
 
+/// Implements `ToBytes` and `FromBytes` via JSON serialization/deserialization for the given type.
+///
+/// This macro generates:
+/// - a `ToBytes` impl that serializes the type to a `Vec<u8>` using `serde_json::to_vec`
+///   and wraps it in `seda_sdk_rs::Bytes`.
+/// - a `FromBytes` impl that deserializes from a `&[u8]` or `Vec<u8>` using `serde_json::from_slice`.
+///
+/// # Example
+///
+/// # Example
+///
+/// ```
+/// use serde::{Serialize, Deserialize};
+/// use seda_sdk_rs::bytes::{Bytes, ToBytes, FromBytes};
+/// use seda_sdk_rs::bytes_serde_json;
+///
+/// #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
+/// struct MyType { foo: String, bar: i32 }
+///
+/// // Generate the ToBytes/FromBytes impls
+/// bytes_serde_json!(MyType);
+///
+/// let original = MyType { foo: "hi".into(), bar: 123 };
+/// let bytes = original.clone().to_bytes();
+/// let decoded = MyType::from_bytes(&bytes).unwrap();
+/// assert_eq!(original, decoded);
+/// ```
 #[macro_export]
 macro_rules! bytes_serde_json {
     ($type_:ty) => {
-        impl ToBytes for $type_ {
-            fn to_bytes(self) -> seda_runtime_sdk::Bytes {
+        impl $crate::bytes::ToBytes for $type_ {
+            fn to_bytes(self) -> $crate::bytes::Bytes {
                 serde_json::to_vec(&self).unwrap().to_bytes()
             }
         }
 
-        impl FromBytes for $type_ {
-            fn from_bytes(bytes: &[u8]) -> seda_runtime_sdk::Result<Self> {
+        impl $crate::bytes::FromBytes for $type_ {
+            fn from_bytes(bytes: &[u8]) -> $crate::errors::Result<Self> {
                 Ok(serde_json::from_slice(bytes)?)
             }
 
-            fn from_bytes_vec(bytes: Vec<u8>) -> seda_runtime_sdk::Result<Self> {
+            fn from_bytes_vec(bytes: Vec<u8>) -> $crate::errors::Result<Self> {
                 Self::from_bytes(&bytes)
             }
         }

--- a/libs/rs-sdk/sdk/src/errors.rs
+++ b/libs/rs-sdk/sdk/src/errors.rs
@@ -1,21 +1,33 @@
+//! Error definitions and result type for the `seda_runtime_sdk`.
+//!
+//! This module provides the [`SDKError`] enum representing all possible errors
+//! within the SDK, and a convenient [`Result`] alias for SDK operations.
+
 use thiserror::Error;
 
+/// Represents errors that can occur when using the `seda_runtime_sdk`.
 #[derive(Debug, Error)]
 pub enum SDKError {
+    /// Wraps errors from JSON serialization or deserialization.
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
 
+    /// Wraps errors arising from converting bytes into a UTF-8 `String`.
     #[error(transparent)]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
 
+    /// Errors encountered when interpreting raw bytes as UTF-8.
     #[error("{0:?}")]
     StringBytesConversion(#[from] std::str::Utf8Error),
 
+    /// Wraps errors when converting a byte slice into a fixed-size array.
     #[error(transparent)]
     NumBytesConversion(#[from] std::array::TryFromSliceError),
 
+    /// Indicates that a value did not meet expected constraints.
     #[error("Invalid value")]
     InvalidValue,
 }
 
+/// A specialized `Result` type for SDK operations that return `SDKError`.
 pub type Result<T, E = SDKError> = core::result::Result<T, E>;

--- a/libs/rs-sdk/sdk/src/hashmap.rs
+++ b/libs/rs-sdk/sdk/src/hashmap.rs
@@ -1,17 +1,26 @@
+//! A deterministic [`HashMap`] for tally oracle programs without random hashing.
+//!
+//! The standard [`std::collections::HashMap`] relies on randomized seeds, which are disallowed in tally
+//! oracle programs. This module provides [`DeterministicHasher`] and a [`HashMap`] alias
+//! that guarantees consistent, reproducible hashes without any randomness.
+
 use std::{
     collections::HashMap as StdHashMap,
     hash::{BuildHasher, DefaultHasher},
 };
 
+/// A hasher that always produces deterministic outputs by wrapping `DefaultHasher`.
 pub struct DeterministicHasher {}
 
 impl DeterministicHasher {
+    /// Creates a new `DeterministicHasher`.
     pub fn new() -> Self {
         Self {}
     }
 }
 
 impl Default for DeterministicHasher {
+    /// Returns a default `DeterministicHasher`.
     fn default() -> Self {
         Self::new()
     }
@@ -20,9 +29,11 @@ impl Default for DeterministicHasher {
 impl BuildHasher for DeterministicHasher {
     type Hasher = DefaultHasher;
 
+    /// Builds a new `DefaultHasher` for deterministic hashing.
     fn build_hasher(&self) -> Self::Hasher {
         DefaultHasher::new()
     }
 }
 
+/// A `HashMap` type alias using `DeterministicHasher` to ensure consistent hash values.
 pub type HashMap<K, V> = StdHashMap<K, V, DeterministicHasher>;

--- a/libs/rs-sdk/sdk/src/keccak256.rs
+++ b/libs/rs-sdk/sdk/src/keccak256.rs
@@ -1,19 +1,17 @@
+//! Keccak-256 hashing for the `seda_runtime_sdk` for oracle programs.
+//!
+//! This module provides the [`keccak256`] function to compute the Keccak-256 hash of a message
+//! using the VM's FFI interface.
+
+///
 /// Computes the Keccak-256 hash of a message.
 ///
 /// The Keccak-256 hash function is a cryptographic hash function that produces a 32-byte (256-bit) hash value.
 ///
-/// # Arguments
-///
-/// * `message` - The input bytes to hash
-///
-/// # Returns
-///
-/// A 32-byte vector containing the Keccak-256 hash of the input
-///
 /// # Examples
 ///
-/// ```
-/// use seda_sdk::keccak256::keccak256;
+/// ```no_run
+/// use seda_sdk_rs::keccak256::keccak256;
 ///
 /// let message = b"Hello, world!".to_vec();
 /// let hash = keccak256(message);

--- a/libs/rs-sdk/sdk/src/lib.rs
+++ b/libs/rs-sdk/sdk/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc = include_str!("../../README.md")]
+#![deny(missing_docs)]
+
 pub mod bytes;
 pub mod errors;
 pub mod hashmap;
@@ -23,7 +26,7 @@ pub use tally::*;
 pub use seda_sdk_macros::oracle_program;
 
 #[cfg(feature = "hide-panic-paths")]
-/// A function run before the main function, via `ctor::ctor`, to set a sanitized panic hook.
+/// A function run before the main function, via [`ctor::ctor`], to set a sanitized panic hook.
 /// This hook takes the `std::panic::PanicInfo` and attempts to downcast the payload to a string.
 /// If unsuccessful, it defaults to printing "<panic>".
 /// It then gracefully aborts the process.

--- a/libs/rs-sdk/sdk/src/log.rs
+++ b/libs/rs-sdk/sdk/src/log.rs
@@ -1,3 +1,5 @@
+//! Logging and debugging macros for the `seda_runtime_sdk`.
+
 /// A debug macro that prints the expression and its value to stderr.
 ///
 /// This macro is a more gas-efficient alternative to the standard `dbg!` macro.
@@ -7,6 +9,8 @@
 /// # Examples
 ///
 /// ```
+/// use seda_sdk_rs::debug;
+///
 /// let a = 2;
 /// let b = debug!(a * 2) + 1;
 /// // Prints to stderr: [src/main.rs:2:9] a * 2 = 4
@@ -16,6 +20,8 @@
 /// Multiple values can be debugged at once:
 ///
 /// ```
+/// use seda_sdk_rs::debug;
+///
 /// let x = 1;
 /// let y = 2;
 /// debug!(x, y, x + y);
@@ -32,7 +38,9 @@ macro_rules! debug {
             expr => {
                 use std::io::Write;
                 // Format the debug message
-                std::io::stderr().write_all(format!("[{}:{}] {} = {:#?}\n", file!(), line!(), stringify!($expr), &expr).as_bytes())?;
+                if let Err(e) = std::io::stderr().write_all(format!("[{}:{}] {} = {:#?}\n", file!(), line!(), stringify!($expr), &expr).as_bytes()) {
+                    panic!("Failed to write debug message: {e}");
+                }
 
                 expr
             }

--- a/libs/rs-sdk/sdk/src/process.rs
+++ b/libs/rs-sdk/sdk/src/process.rs
@@ -6,7 +6,7 @@
 //! # Examples
 //!
 //! ```no_run
-//! use seda_sdk::process::Process;
+//! use seda_sdk_rs::process::Process;
 //!
 //! // Handle success case
 //! let result = vec![1, 2, 3];
@@ -35,8 +35,8 @@ impl Process {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// ```
+    /// use seda_sdk_rs::process::Process;
     ///
     /// let args = Process::args();
     /// // args[0] is the program name
@@ -50,10 +50,13 @@ impl Process {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// ```
+    /// use seda_sdk_rs::process::Process;
+    ///
+    /// std::env::set_var("TEST_VAR", "test_value");
     ///
     /// let env_vars = Process::envs();
+    /// assert!(env_vars.contains_key("TEST_VAR"));
     /// for (key, value) in env_vars {
     ///     println!("{}: {}", key, value);
     /// }
@@ -64,10 +67,16 @@ impl Process {
 
     /// Retrieves and decodes the data request inputs
     ///
+    /// # Panics
+    ///
+    /// This function will panic if:
+    /// - There were no arguments passed to the program.
+    /// - The second argument (index 1) is not a valid hex string.
+    ///
     /// # Examples
     ///
     /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// use seda_sdk_rs::process::Process;
     ///
     /// let input_bytes = Process::get_inputs();
     /// // Process the input bytes...
@@ -81,6 +90,11 @@ impl Process {
     }
 
     /// Gets the VM mode from environment variables.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the `VM_MODE` environment variable is not set.
+    /// Which should never happen in a properly configured environment.
     fn get_vm_mode() -> String {
         env::var(VM_MODE_ENV_KEY).expect("VM_MODE is not set in environment")
     }
@@ -89,9 +103,10 @@ impl Process {
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// ```
+    /// use seda_sdk_rs::process::Process;
     ///
+    /// std::env::set_var("VM_MODE", "tally");
     /// if Process::is_tally_vm_mode() {
     ///     // Handle tally mode specific logic
     /// }
@@ -105,7 +120,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// use seda_sdk_rs::process::Process;
     ///
     /// if Process::is_dr_vm_mode() {
     ///     let replication = Process::replication_factor();
@@ -121,7 +136,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// use seda_sdk_rs::process::Process;
     ///
     /// let result = vec![0x01, 0x02, 0x03];
     /// Process::success(&result);
@@ -135,7 +150,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// use seda_sdk_rs::process::Process;
     ///
     /// let error_data = vec![0xFF];
     /// Process::error(&error_data);
@@ -146,10 +161,18 @@ impl Process {
 
     /// Gets the replication factor for the data request
     ///
+    /// # Panics
+    ///
+    /// This function will panic if:
+    /// - The `DR_REPLICATION_FACTOR_ENV_KEY` environment variable is not set.
+    /// - The value of `DR_REPLICATION_FACTOR_ENV_KEY` is not a valid `u16`.
+    ///
+    /// These conditions should never happen in a properly configured environment.
+    ///
     /// # Examples
     ///
     /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// use seda_sdk_rs::process::Process;
     ///
     /// if Process::is_dr_vm_mode() {
     ///     let factor = Process::replication_factor();
@@ -170,7 +193,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// use seda_sdk_rs::process::Process;
     ///
     /// // Exit with an error message
     /// Process::exit_with_message(1, "Operation failed: invalid input");
@@ -188,7 +211,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// use seda_sdk_rs::process::Process;
     ///
     /// let result = vec![1, 2, 3, 4];
     /// Process::exit_with_result(0, &result);
@@ -203,7 +226,7 @@ impl Process {
     /// # Examples
     ///
     /// ```no_run
-    /// use seda_sdk::process::Process;
+    /// use seda_sdk_rs::process::Process;
     ///
     /// // Exit successfully with no result
     /// Process::exit(0);

--- a/libs/rs-sdk/sdk/src/promise.rs
+++ b/libs/rs-sdk/sdk/src/promise.rs
@@ -1,16 +1,24 @@
+//! This module defines the `PromiseStatus` enum, which represents the status of a promise
+//! in the Seda runtime SDK. It can either be fulfilled with a result or rejected with an
+//! error message. The enum provides methods to handle the promise status and convert it from
+//! a [`core::result::Result`] type.
+
 use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{bytes::ToBytes, promise_actions::PromiseAction};
+use crate::bytes::ToBytes;
 
+/// Represents the status of a promise, which can either be fulfilled or rejected.
+/// This enum is returned by the host VM after executing a promise action.
 // TODO: Fulfilled and Rejected could now just be our Bytes type.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum PromiseStatus {
-    /// The promise completed
+    /// The promise completed successfully contains the bytes of the result if any.
     Fulfilled(Option<Vec<u8>>),
 
-    /// There was an error executing this promise
+    /// There was an error executing this promise.
+    /// The error is represented as bytes, which can be a string or any other serialized form.
     // TODO: Is there ever a case where Rejected isn't a string?
     // HTTP rejections could be an object(but encoded in a string).
     // Could private the type and then have methods or something.
@@ -18,8 +26,20 @@ pub enum PromiseStatus {
 }
 
 impl PromiseStatus {
-    /// Helper function that immidiatly assumes that the promise has been
-    /// fulfilled and return the value. Panics if result is not fulfilled
+    /// Helper function that immediately assumes that the promise has been
+    /// fulfilled and returns the value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the promise is not fulfilled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seda_sdk_rs::{promise::PromiseStatus, bytes::ToBytes};
+    /// let promise = PromiseStatus::Fulfilled(Some("Hello, world!".to_bytes().eject()));
+    /// assert_eq!(promise.fulfilled(), b"Hello, world!");
+    /// ```
     pub fn fulfilled(self) -> Vec<u8> {
         if let Self::Fulfilled(Some(value)) = self {
             return value;
@@ -28,14 +48,35 @@ impl PromiseStatus {
         panic!("Promise is not fulfilled: {:?}", &self);
     }
 
-    pub fn parse<T>(self) -> Result<T, T::Error>
+    /// Parses the fulfilled value of the promise into the desired type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the promise is not fulfilled.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the conversion from bytes to the desired type fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seda_sdk_rs::{promise::PromiseStatus, bytes::ToBytes};
+    /// use serde_json::Value;
+    ///
+    /// let value = serde_json::json!({"key": "value"});
+    /// let promise = PromiseStatus::Fulfilled(Some(serde_json::to_vec(&value).unwrap()));
+    ///
+    /// let parsed: Value = promise.parse().unwrap();
+    /// assert_eq!(parsed, value);
+    /// ```
+    pub fn parse<T>(self) -> Result<T, serde_json::Error>
     where
-        T: TryFrom<Vec<u8>>,
-        T: TryFrom<Vec<u8>, Error = serde_json::Error>,
+        T: serde::de::DeserializeOwned,
     {
         let value = self.fulfilled();
 
-        value.try_into()
+        serde_json::from_slice(&value)
     }
 }
 
@@ -55,13 +96,4 @@ impl<T: ToBytes, E: std::error::Error> From<Result<Option<T>, E>> for PromiseSta
             Err(rejection) => PromiseStatus::Rejected(rejection.to_string().to_bytes().eject()),
         }
     }
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct Promise {
-    /// The name of the action we should execute
-    pub action: PromiseAction,
-
-    /// The status of the promise, will include the result if it's fulfilled
-    pub status: PromiseStatus,
 }

--- a/libs/rs-sdk/sdk/src/promise_actions.rs
+++ b/libs/rs-sdk/sdk/src/promise_actions.rs
@@ -1,14 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::http::HttpFetchOptions;
+use crate::http::HttpFetchAction;
 
+/// Represents an action that can be executed asynchronously.
+/// This enum is serialized and sent to the VM for execution.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum PromiseAction {
     Http(HttpFetchAction),
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct HttpFetchAction {
-    pub url: String,
-    pub options: HttpFetchOptions,
 }

--- a/libs/rs-sdk/sdk/src/raw.rs
+++ b/libs/rs-sdk/sdk/src/raw.rs
@@ -1,3 +1,5 @@
+//! This module provides raw FFI bindings to the Seda VM.
+
 #[link(wasm_import_module = "seda_v1")]
 extern "C" {
     pub fn execution_result(result: *const u8, result_length: u32);

--- a/libs/rs-sdk/sdk/src/secp256k1.rs
+++ b/libs/rs-sdk/sdk/src/secp256k1.rs
@@ -1,24 +1,23 @@
+//! This module provides functions for verifying secp256k1 ECDSA signatures
+//! using the Seda VM's FFI interface.
+
 use super::raw;
 
 /// Verifies a secp256k1 ECDSA signature.
 ///
 /// This function verifies that a signature was created by the holder of the private key
-/// corresponding to the provided public key, for the given message.
+/// corresponding to the provided public key, for the given message. If the signature is valid,
+/// it returns `true`; otherwise, it returns `false`.
 ///
-/// # Arguments
+/// # Panics
 ///
-/// * `message` - The message that was signed, as a byte slice
-/// * `signature` - The signature to verify, as a byte slice. Must be 64 bytes in DER format
-/// * `public_key` - The public key to verify against, as a byte slice. From a SEC1-encoded public key.
-///
-/// # Returns
-///
-/// Returns `true` if the signature is valid for the message and public key, `false` otherwise.
+/// Panics if the result from the VM is not a valid boolean (0 or 1).
+/// This is unexpected and indicates a bug in the VM or the signature verification logic, so it should never be hit.
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use seda_sdk::secp256k1::secp256k1_verify;
+/// use seda_sdk_rs::secp256k1::secp256k1_verify;
 ///
 /// let message = b"Hello, world!";
 /// let signature = vec![/* 64 bytes signature */];

--- a/libs/rs-sdk/sdk/src/tally.rs
+++ b/libs/rs-sdk/sdk/src/tally.rs
@@ -1,3 +1,10 @@
+//! This module provides functionality to retrieve and process reveals from the command line arguments
+//! of a data request report in the Seda runtime SDK.
+//!
+//! It defines the [`RevealBody`] and [`RevealResult`] structs to represent the reveal data,
+//! and provides functions to retrieve unfiltered reveals and filtered reveals that are in consensus
+//! via the functions [`get_unfiltered_reveals`] and [`get_reveals`], respectively.
+
 use anyhow::{Error, Result};
 use serde::{Deserialize, Serialize};
 
@@ -6,20 +13,52 @@ use crate::Process;
 const REVEALS_ARGUMENT_POSITION: usize = 2;
 const CONSENSUS_ARGUMENT_POSITION: usize = 3;
 
+/// Represents the body of a reveal body of a data request report.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RevealBody {
+    /// The block height the data request was posted.
     pub dr_block_height: u64,
+    /// The exit code of the data request's execution VM.
     pub exit_code: u8,
+    /// The gas used by the data request's execution VM.
     pub gas_used: u64,
+    /// The data returned by the data request's execution VM.
     pub reveal: Vec<u8>,
 }
 
+/// Represents a reveal body of a data request report.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RevealResult {
+    /// The body of the reveal.
     pub body: RevealBody,
+    /// Whether the reveal is in consensus or not.
     pub in_consensus: bool,
 }
 
+/// Retrieves the unfiltered reveals from the command line arguments.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - The expected arguments are not found in the command line arguments.
+/// - The number of reveals does not match the number of consensus reports.
+/// - The JSON deserialization fails for either the reveals or the consensus reports.
+///
+/// # Examples
+///
+/// ```no_run
+/// use seda_sdk_rs::get_unfiltered_reveals;
+/// match get_unfiltered_reveals() {
+///     Ok(reveals) => {
+///        for reveal in reveals {
+///            // Process each reveal
+///        }
+///     },
+///     Err(err) => {
+///         eprintln!("Error retrieving unfiltered reveals: {}", err);
+///     }
+/// }
+/// ```
 pub fn get_unfiltered_reveals() -> Result<Vec<RevealResult>> {
     let args = Process::args();
 
@@ -58,6 +97,26 @@ pub fn get_unfiltered_reveals() -> Result<Vec<RevealResult>> {
     Ok(reveal_results)
 }
 
+/// Retrieves the reveals that are in consensus from the command line arguments.
+///
+/// # Errors
+/// This function will return an error if the unfiltered reveals cannot be retrieved see [`get_unfiltered_reveals`]
+/// for more information.
+///
+/// # Examples
+/// ```no_run
+/// use seda_sdk_rs::get_reveals;
+/// match get_reveals() {
+///    Ok(reveals) => {
+///       for reveal in reveals {
+///           // Process each reveal that is in consensus
+///       }
+///   },
+///   Err(err) => {
+///       eprintln!("Error retrieving reveals: {}", err);
+///   }
+/// }
+/// ```
 pub fn get_reveals() -> Result<Vec<RevealResult>> {
     let unfiltered_reveals = get_unfiltered_reveals()?;
 

--- a/libs/rs-sdk/sdk/src/vm_modes.rs
+++ b/libs/rs-sdk/sdk/src/vm_modes.rs
@@ -1,3 +1,5 @@
+//! This module defines constants for VM modes and oracle program configurations.
+
 pub const VM_MODE_ENV_KEY: &str = "VM_MODE";
 pub const VM_MODE_TALLY: &str = "tally";
 pub const VM_MODE_DR: &str = "dr";


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So when we publish the crate to `crates.io` the `rust` docs follow the `rust` docs standard, and build.

## Explanation of Changes

- Adds the `crates.io` and `docs.rs` badges to the rs sdk readme.
- Fixes some existing rust docs to compile:
  - when cargo docs is run
  - have running tests where they can
  - have proper paths and etc in the examples
- Fixes some macros:
  - Debug macro fails if not used in a function that returns a convertible result type.
  - Macro to generate JSON types now works.
- De-complicates generic parse function- made the docs stuff happier and works the same way.
- Rust will now error if something is undocumented.

TLDR mostly doc changes, small other things that should not break compatibility at all,
docs will be generated once we publish on `crates.io`.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Running docs command and test command is happy.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

N/A
