### PR TITLE
chore: Proxy http fetch

### DIFF
--- a/libs/as-sdk-integration-tests/assembly/proxy-http.ts
+++ b/libs/as-sdk-integration-tests/assembly/proxy-http.ts
@@ -14,7 +14,7 @@ export class TestProxyHttpFetch extends OracleProgram {
 			Process.success(response.bytes);
 		}
 
-		Process.error(response.bytes);
+		Process.error(Bytes.fromUtf8String("rejected"));
 	}
 }
 

--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",
@@ -20,7 +20,7 @@
 		"@cosmjs/tendermint-rpc": "^0.32.4",
 		"@seda-protocol/proto-messages": "1.0.0",
 		"@seda-protocol/utils": "^1.3.0",
-		"@seda-protocol/vm": "^1.0.15",
+		"@seda-protocol/vm": "^1.0.16",
 		"big.js": "^6.2.1",
 		"dotenv": "^16.3.1",
 		"fetch-cookie": "^3.1.0",

--- a/libs/dev-tools/src/lib/testing/test-oracle-program.ts
+++ b/libs/dev-tools/src/lib/testing/test-oracle-program.ts
@@ -38,6 +38,7 @@ export function testOracleProgramExecution(
 	adapterOptions?: {
 		totalHttpTimeLimit?: number;
 	},
+	mockProxyGasCost: bigint | undefined = undefined,
 ) {
 	return callVm(
 		{
@@ -48,7 +49,11 @@ export function testOracleProgramExecution(
 			vmMode: "exec",
 		},
 		undefined,
-		new DataRequestVmAdapter({ fetchMock, ...adapterOptions }),
+		new DataRequestVmAdapter({
+			fetchMock,
+			mockProxyGasCost,
+			...adapterOptions,
+		}),
 		sync,
 	);
 }

--- a/libs/rs-sdk-integration-tests/src/proxy_http.rs
+++ b/libs/rs-sdk-integration-tests/src/proxy_http.rs
@@ -13,7 +13,7 @@ pub fn test_proxy_http_fetch() {
         return;
     }
 
-    Process::error(&response.bytes);
+    Process::error(&"rejected".to_bytes());
 }
 
 pub fn test_generate_proxy_http_message() {

--- a/libs/vm/package.json
+++ b/libs/vm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/vm",
 	"type": "module",
-	"version": "1.0.15",
+	"version": "1.0.16",
 	"dependencies": {
 		"@seda-protocol/wasm-metering-ts": "^2.0.1",
 		"uwasi": "^1.4.1",

--- a/libs/wasm-integration-tests/tests/universal/http.test.ts
+++ b/libs/wasm-integration-tests/tests/universal/http.test.ts
@@ -42,6 +42,30 @@ describe.each(sdks)("%s:Http", (_, oracleProgram) => {
 		expect(result.resultAsString).toEqual("200:999:mocked:true");
 	});
 
+	it("Test mocked SDK Proxy HTTP Success in a sync environment", async () => {
+		const json = JSON.stringify({
+			userId: 200,
+			id: 999,
+			title: "mocked",
+			completed: true,
+		});
+		const mockResponse = new Response(json);
+		mockHttpFetch.mockResolvedValue(mockResponse);
+
+		const result = await testOracleProgramExecution(
+			oracleProgram,
+			Buffer.from("testProxyHttpFetch"),
+			mockHttpFetch,
+			undefined,
+			true,
+			undefined,
+			0n,
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toEqual(json);
+	});
+
 	it("Test SDK HTTP Rejection", async () => {
 		const result = await testOracleProgramExecution(
 			oracleProgram,
@@ -50,6 +74,21 @@ describe.each(sdks)("%s:Http", (_, oracleProgram) => {
 		);
 
 		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toEqual("rejected");
+	});
+
+	it("Test SDK Proxy HTTP Rejection", async () => {
+		const result = await testOracleProgramExecution(
+			oracleProgram,
+			Buffer.from("testProxyHttpFetch"),
+			mockHttpFetch,
+			undefined,
+			false,
+			undefined,
+			0n,
+		);
+
+		expect(result.exitCode).toBe(1);
 		expect(result.resultAsString).toEqual("rejected");
 	});
 
@@ -74,6 +113,30 @@ describe.each(sdks)("%s:Http", (_, oracleProgram) => {
 		expect(result.resultAsString).toEqual("200:999:mocked:true");
 	});
 
+	it("Test mocked Proxy SDK HTTP Success", async () => {
+		const json = JSON.stringify({
+			userId: 200,
+			id: 999,
+			title: "mocked",
+			completed: true,
+		});
+		const mockResponse = new Response(json);
+		mockHttpFetch.mockResolvedValue(mockResponse);
+
+		const result = await testOracleProgramExecution(
+			oracleProgram,
+			Buffer.from("testProxyHttpFetch"),
+			mockHttpFetch,
+			undefined,
+			false,
+			undefined,
+			0n,
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toEqual(json);
+	});
+
 	// Possibly flakey as it relies on internet connectivity and an external service
 	it("Test SDK HTTP Success", async () => {
 		const result = await testOracleProgramExecution(
@@ -96,5 +159,46 @@ describe.each(sdks)("%s:Http", (_, oracleProgram) => {
 		expect(result.resultAsString).toEqual(
 			"101:Test SDK:Don't forget to test some integrations.",
 		);
+	});
+
+	it("Test SDK Proxy HTTP Cost", async () => {
+		const json = JSON.stringify({
+			userId: 200,
+			id: 999,
+			title: "mocked",
+			completed: true,
+		});
+		const mockResponse = new Response(json);
+		mockHttpFetch.mockResolvedValue(mockResponse);
+
+		const result1 = await testOracleProgramExecution(
+			oracleProgram,
+			Buffer.from("testProxyHttpFetch"),
+			mockHttpFetch,
+			undefined,
+			false,
+			undefined,
+			100n,
+		);
+
+		expect(result1.exitCode).toBe(0);
+		expect(result1.resultAsString).toEqual(json);
+
+		const mockResponse2 = new Response(json);
+		mockHttpFetch.mockResolvedValue(mockResponse2);
+		const result2 = await testOracleProgramExecution(
+			oracleProgram,
+			Buffer.from("testProxyHttpFetch"),
+			mockHttpFetch,
+			undefined,
+			false,
+			undefined,
+			0n,
+		);
+
+		expect(result2.exitCode).toBe(0);
+		expect(result2.resultAsString).toEqual(json);
+
+		expect(result1.gasUsed - result2.gasUsed).toBe(100n);
 	});
 });


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

So we can write tests for the proxy http fetch calls.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Adds a way to change the proxy gas cost, via a named argument.
If that is set and the existing proxy function is set it will mock the proxy fetch.

A few caveats:
- I reuse the same mock. IMO, this is fine since you can just match on the URL already. If we preferred it to be separate, LMK.
- In the mock proxy, I don't do header validations, it simply forwards the request to the normal http fetch action. I figured setting up identifies, etc. for testing could be annoying, but we could add that functionality in dev-tools for testing as well. So let me know if we prefer that as well.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tested with the seda-example-ops repo locally and it works!

A few new tests added as well.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #201 
