### PR TITLE
feat: add ability to mock clock time for the execution

### DIFF
--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",
@@ -20,7 +20,7 @@
 		"@cosmjs/tendermint-rpc": "^0.32.4",
 		"@seda-protocol/proto-messages": "1.0.0",
 		"@seda-protocol/utils": "^1.3.0",
-		"@seda-protocol/vm": "^1.1.0",
+		"@seda-protocol/vm": "^1.1.2",
 		"big.js": "^6.2.1",
 		"dotenv": "^16.3.1",
 		"fetch-cookie": "^3.1.0",

--- a/libs/dev-tools/src/lib/testing/test-oracle-program.ts
+++ b/libs/dev-tools/src/lib/testing/test-oracle-program.ts
@@ -37,6 +37,7 @@ export function testOracleProgramExecution(
 	sync?: boolean,
 	adapterOptions?: {
 		totalHttpTimeLimit?: number;
+		clockTime?: number;
 	},
 	mockProxyGasCost: bigint | undefined = undefined,
 ) {

--- a/libs/vm/package.json
+++ b/libs/vm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/vm",
 	"type": "module",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"dependencies": {
 		"@seda-protocol/wasm-metering-ts": "^2.0.1",
 		"uwasi": "^1.4.1",

--- a/libs/vm/src/data-request-vm-adapter.ts
+++ b/libs/vm/src/data-request-vm-adapter.ts
@@ -19,6 +19,13 @@ interface Options {
 	mockProxyGasCost?: bigint;
 	maxResponseBytes?: number;
 	totalHttpTimeLimit?: number;
+
+	/**
+	 * The clock time to use for the VM.
+	 * If not provided, the current time will be used.
+	 * This is useful for testing purposes.
+	 */
+	clockTime?: number;
 }
 
 export default class DataRequestVmAdapter implements VmAdapter {
@@ -208,6 +215,19 @@ export default class DataRequestVmAdapter implements VmAdapter {
 				}),
 			);
 		}
+	}
+
+	getClockTime(mode: "monotonic" | "realtime"): number {
+		if (this.opts?.clockTime) {
+			return this.opts.clockTime;
+		}
+
+		if (mode === "monotonic") {
+			return performance.now();
+		}
+
+		// Default to realtime if no mode is provided
+		return Date.now();
 	}
 }
 

--- a/libs/vm/src/imports/wasi/clock_time_get.ts
+++ b/libs/vm/src/imports/wasi/clock_time_get.ts
@@ -1,12 +1,61 @@
+import type { Maybe } from "true-myth";
+import type { WASI } from "uwasi";
 import { CallType, type GasMeter } from "../../metering";
-import { extractFunctionFromImportValue } from "../import-utils";
+import type { VmAdapter } from "../../types/vm-adapter";
+
+const ABI_WASI_CLOCK_MONOTONIC = 1;
+const ABI_WASI_CLOCK_REALTIME = 0;
+const ABI_WASI_ENOSYS = 52;
+const ABI_WASI_ESUCCESS = 0;
 
 export function clock_time_get(
+	vmAdapter: Maybe<VmAdapter>, // TODO: Can be none due the usage of the SharedArrayBuffer. We should get rid of this.
+	wasi: WASI,
 	gasMeter: GasMeter,
-	importValue: WebAssembly.ImportValue,
 	...args: number[]
 ) {
 	gasMeter.applyGasCost(CallType.ClockTimeGet, BigInt(0));
-	const func = extractFunctionFromImportValue("clock_time_get", importValue);
-	return func(...args);
+	const [clockId, precision, time] = args;
+
+	// Taken from uwasi/lib/esm/features/clock.js
+	let nowMs = 0;
+	switch (clockId) {
+		case ABI_WASI_CLOCK_MONOTONIC: {
+			nowMs = vmAdapter.match({
+				Just: (adapter) => adapter.getClockTime("monotonic"),
+				Nothing: () => performance.now(),
+			});
+			break;
+		}
+		case ABI_WASI_CLOCK_REALTIME: {
+			nowMs = vmAdapter.match({
+				Just: (adapter) => adapter.getClockTime("realtime"),
+				Nothing: () => Date.now(),
+			});
+			break;
+		}
+		default:
+			return ABI_WASI_ENOSYS;
+	}
+
+	// @ts-expect-error - view is private and only accessible within class 'WASI'.
+	const view: DataView = wasi.view();
+
+	if (BigInt) {
+		const msToNs = (ms: number) => {
+			const msInt = Math.trunc(ms);
+			const decimal = BigInt(Math.round((ms - msInt) * 1000000));
+			const ns = BigInt(msInt) * BigInt(1000000);
+			return ns + decimal;
+		};
+		const now = BigInt(msToNs(nowMs));
+		view.setBigUint64(time, now, true);
+	} else {
+		// Fallback to two 32-bit numbers losing precision
+		const now = Date.now() * 1000000;
+		view.setUint32(time, now & 0x0000ffff, true);
+		view.setUint32(time + 4, now & 0xffff0000, true);
+	}
+
+	return ABI_WASI_ESUCCESS;
 }

--- a/libs/vm/src/tally-vm-adapter.ts
+++ b/libs/vm/src/tally-vm-adapter.ts
@@ -76,4 +76,13 @@ export default class TallyVmAdapter implements VmAdapter {
 			}),
 		);
 	}
+
+	getClockTime(mode: "monotonic" | "realtime"): number {
+		if (mode === "monotonic") {
+			return performance.now();
+		}
+
+		// Default to realtime if no mode is provided
+		return Date.now();
+	}
 }

--- a/libs/vm/src/types/vm-adapter.ts
+++ b/libs/vm/src/types/vm-adapter.ts
@@ -48,4 +48,16 @@ export interface VmAdapter {
 	proxyHttpFetch(
 		action: ProxyHttpFetchAction,
 	): Promise<PromiseStatus<HttpFetchResponse>>;
+
+	/**
+	 * Method to get the current clock time
+	 *
+	 * @param mode
+	 *
+	 * 'monotonic' - The store-wide monotonic clock, which is defined as a clock measuring real time, whose value cannot be adjusted and which cannot have negative clock jumps. The epoch of this clock is undefined. The absolute time value of this clock therefore has no meaning.
+	 * 'realtime' - the time since the Unix epoch (January 1, 1970 00:00:00 UTC)
+	 *
+	 * @returns the current clock time in milliseconds
+	 */
+	getClockTime(mode: "monotonic" | "realtime"): number;
 }

--- a/libs/vm/src/vm-imports.test.ts
+++ b/libs/vm/src/vm-imports.test.ts
@@ -1,18 +1,31 @@
 import { describe, expect, it } from "bun:test";
+import DataRequestVmAdapter from "./data-request-vm-adapter";
 import { GasMeter } from "./metering";
+import { createWasi } from "./services/wasm-module";
+import type { VmCallData } from "./types/vm-call-data";
 import VmImports from "./vm-imports";
 
 describe("vm-imports", () => {
 	it("should only add allowed WASI imports", () => {
+		const callData: VmCallData = {
+			args: [],
+			binary: new Uint8Array(),
+			envs: {},
+			allowedImports: ["args_get"],
+			vmMode: "exec",
+		};
+
+		const wasi = createWasi(
+			callData,
+			(line) => {},
+			(line) => {},
+		);
+
 		const vmImports = new VmImports(
+			wasi,
 			new GasMeter(1n),
 			"1",
-			{
-				args: [],
-				binary: new Uint8Array(),
-				envs: {},
-				allowedImports: ["args_get"],
-			},
+			callData,
 			new SharedArrayBuffer(1),
 		);
 
@@ -30,15 +43,25 @@ describe("vm-imports", () => {
 	});
 
 	it("should only add allowed WASI imports even on multiple versions", () => {
+		const callData: VmCallData = {
+			args: [],
+			binary: new Uint8Array(),
+			envs: {},
+			allowedImports: ["args_get"],
+			vmMode: "exec",
+		};
+
+		const wasi = createWasi(
+			callData,
+			(line) => {},
+			(line) => {},
+		);
+
 		const vmImports = new VmImports(
+			wasi,
 			new GasMeter(1n),
 			"1",
-			{
-				args: [],
-				binary: new Uint8Array(),
-				envs: {},
-				allowedImports: ["args_get"],
-			},
+			callData,
 			new SharedArrayBuffer(1),
 		);
 
@@ -65,15 +88,23 @@ describe("vm-imports", () => {
 	});
 
 	it("Empty array should disallow all imports except for the pre-configured WASI imports", () => {
+		const callData: VmCallData = {
+			args: [],
+			binary: new Uint8Array(),
+			envs: {},
+			allowedImports: [],
+			vmMode: "exec",
+		};
+		const wasi = createWasi(
+			callData,
+			(line) => {},
+			(line) => {},
+		);
 		const vmImports = new VmImports(
+			wasi,
 			new GasMeter(1n),
 			"1",
-			{
-				args: [],
-				binary: new Uint8Array(),
-				envs: {},
-				allowedImports: [],
-			},
+			callData,
 			new SharedArrayBuffer(1),
 		);
 
@@ -90,14 +121,22 @@ describe("vm-imports", () => {
 	});
 
 	it("undefined allowedImports should allow all", () => {
+		const callData: VmCallData = {
+			args: [],
+			binary: new Uint8Array(),
+			envs: {},
+			vmMode: "exec",
+		};
+		const wasi = createWasi(
+			callData,
+			(line) => {},
+			(line) => {},
+		);
 		const vmImports = new VmImports(
+			wasi,
 			new GasMeter(1n),
 			"1",
-			{
-				args: [],
-				binary: new Uint8Array(),
-				envs: {},
-			},
+			callData,
 			new SharedArrayBuffer(1),
 		);
 

--- a/libs/vm/src/vm-imports.ts
+++ b/libs/vm/src/vm-imports.ts
@@ -2,6 +2,7 @@ import * as Secp256k1 from "@noble/secp256k1";
 import { trySync } from "@seda-protocol/utils";
 import { Maybe } from "true-myth";
 import type { ResultJSON } from "true-myth/result";
+import type { WASI } from "uwasi";
 import { VmError, VmErrorType } from "./errors.js";
 import { args_get, args_sizes_get } from "./imports/wasi/args_get.js";
 import { clock_time_get } from "./imports/wasi/clock_time_get.js";
@@ -41,10 +42,11 @@ export default class VmImports {
 	reExecutionRequest?: VmActionRequest;
 
 	constructor(
+		private wasi: WASI,
 		gasMeter: GasMeter,
 		processId: string,
 		callData: VmCallData,
-		notifierBufferOrAdapter: SharedArrayBuffer | VmAdapter,
+		private notifierBufferOrAdapter: SharedArrayBuffer | VmAdapter,
 		asyncRequests: VmActionRequest[] = [],
 	) {
 		this.workerToHost = new WorkerToHost(
@@ -321,6 +323,10 @@ export default class VmImports {
 		}
 
 		const injectedWasi: WebAssembly.Imports = {};
+		const vmAdapter: Maybe<VmAdapter> =
+			this.notifierBufferOrAdapter instanceof SharedArrayBuffer
+				? Maybe.nothing()
+				: Maybe.just(this.notifierBufferOrAdapter);
 
 		for (const wasiNamespace of Object.keys(wasiImports)) {
 			injectedWasi[wasiNamespace] = {
@@ -374,11 +380,7 @@ export default class VmImports {
 					),
 				proc_exit: wasiImports[wasiNamespace].proc_exit,
 				clock_time_get: (...args: number[]) =>
-					clock_time_get(
-						this.gasMeter,
-						wasiImports[wasiNamespace].clock_time_get,
-						...args,
-					),
+					clock_time_get(vmAdapter, this.wasi, this.gasMeter, ...args),
 			};
 		}
 

--- a/libs/vm/src/vm.ts
+++ b/libs/vm/src/vm.ts
@@ -55,7 +55,18 @@ export class ExecuteVm {
 			callData.gasLimit ?? BigInt(Number.MAX_SAFE_INTEGER),
 		);
 
+		const wasi = createWasi(
+			this.callData,
+			(line) => {
+				this.stdout += line;
+			},
+			(line) => {
+				this.stderr += line;
+			},
+		);
+
 		this.vmImports = new VmImports(
+			wasi,
 			this.gasMeter,
 			this.processId,
 			this.callData,
@@ -113,6 +124,7 @@ export class ExecuteVm {
 			);
 
 			this.vmImports = new VmImports(
+				wasi,
 				this.gasMeter,
 				this.processId,
 				this.callData,

--- a/libs/wasm-integration-tests/tests/rs-sdk/clock.test.ts
+++ b/libs/wasm-integration-tests/tests/rs-sdk/clock.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, setDefaultTimeout } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { testOracleProgramExecution } from "@seda/dev-tools";
 import { oracleProgram } from "./oracle-program";
 
@@ -17,5 +17,21 @@ describe("rs-sdk:clock", () => {
 		expect(result.exitCode).toBe(0);
 		// Max drift of 100ms (If it drift more than 100ms, it means that the program is not using the correct clock)
 		expect(Math.abs(timestamp - resultTimestamp)).toBeLessThan(100);
+	});
+
+	it("should get the current time using the clock time option", async () => {
+		const result = await testOracleProgramExecution(
+			oracleProgram,
+			Buffer.from("testClockTimeGet"),
+			undefined,
+			undefined,
+			true,
+			{
+				clockTime: 1000,
+			},
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("1000");
 	});
 });


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Add ability to mock clock time

## Explanation of Changes

* Add extra option to set the clock time
* If not set it will use the default Date.now or performance.now depending on the clock mode
* Taken from uwasi and modified (uwasi has no option to set the time)

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

`bun run test`

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

closes #213 