### PR TITLE
fix(vm): prevent lost host-call wakeups in the worker Atomics bridge

### DIFF
--- a/libs/vm/src/worker-host-communication.test.ts
+++ b/libs/vm/src/worker-host-communication.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import { Worker } from "node:worker_threads";
+import { setTimeout as sleep } from "node:timers/promises";
+import { AtomicState } from "./worker-host-communication.js";
+
+const NOTIFIER_INDEX = 0;
+const READY_INDEX = 1;
+
+const MODULE_URL = new URL("./worker-host-communication.ts", import.meta.url)
+	.href;
+
+const makeNotifierBuffer = (initial: AtomicState) => {
+	const sab = new SharedArrayBuffer(8);
+	const buffer = new Int32Array(sab);
+	Atomics.store(buffer, NOTIFIER_INDEX, initial);
+	return { sab, buffer };
+};
+
+/**
+ * Runs waitForNotifierStateChange on a separate thread (the worker role in
+ * production) so the test thread can play the host: observe the notifier
+ * slot while the waiter blocks, then advance the state to release it.
+ * Resolves with the final state the waiter observed after waking.
+ */
+const spawnWaiter = (sab: SharedArrayBuffer, initialState: AtomicState) => {
+	const worker = new Worker(
+		`
+		const { workerData, parentPort } = require("node:worker_threads");
+		const buffer = new Int32Array(workerData.sab);
+		(async () => {
+			const mod = await import(workerData.moduleUrl);
+			Atomics.store(buffer, ${READY_INDEX}, 1);
+			Atomics.notify(buffer, ${READY_INDEX});
+			mod.waitForNotifierStateChange(buffer, workerData.initialState);
+			parentPort.postMessage(Atomics.load(buffer, ${NOTIFIER_INDEX}));
+		})();
+		`,
+		{ eval: true, workerData: { sab, initialState, moduleUrl: MODULE_URL } },
+	);
+
+	const finalState = new Promise<number>((resolve, reject) => {
+		worker.once("message", resolve);
+		worker.once("error", reject);
+	});
+
+	return { worker, finalState };
+};
+
+const waitForReady = (buffer: Int32Array) => {
+	while (Atomics.load(buffer, READY_INDEX) !== 1) {
+		Atomics.wait(buffer, READY_INDEX, 0, 50);
+	}
+};
+
+describe("waitForNotifierStateChange", () => {
+	it("returns immediately when the host already advanced past the awaited state", async () => {
+		const { buffer } = makeNotifierBuffer(AtomicState.ResponseResultLength);
+		const { waitForNotifierStateChange } = await import(MODULE_URL);
+
+		waitForNotifierStateChange(buffer, AtomicState.RequestResultLength);
+
+		expect(Atomics.load(buffer, NOTIFIER_INDEX)).toBe(
+			AtomicState.ResponseResultLength,
+		);
+	});
+
+	it("never writes to the notifier slot while waiting, so a concurrent host store cannot be lost", async () => {
+		const { sab, buffer } = makeNotifierBuffer(AtomicState.Initial);
+		const { worker, finalState } = spawnWaiter(
+			sab,
+			AtomicState.RequestResultLength,
+		);
+
+		try {
+			waitForReady(buffer);
+
+			// The lost-wakeup bug: the previous implementation stored the awaited
+			// state into the slot before waiting. A host store landing between
+			// the waiter's read and that write got overwritten, and the waiter
+			// slept forever on a notify that had already fired. The wait must
+			// observe, never write: the slot stays exactly as the host left it.
+			for (let i = 0; i < 20; i++) {
+				expect(Atomics.load(buffer, NOTIFIER_INDEX)).toBe(AtomicState.Initial);
+				await sleep(2);
+			}
+
+			Atomics.store(buffer, NOTIFIER_INDEX, AtomicState.ResponseResultLength);
+			Atomics.notify(buffer, NOTIFIER_INDEX);
+
+			expect(await finalState).toBe(AtomicState.ResponseResultLength);
+		} finally {
+			await worker.terminate();
+		}
+	});
+
+	it("wakes when the host advances the state mid-wait", async () => {
+		const { sab, buffer } = makeNotifierBuffer(AtomicState.Initial);
+		const { worker, finalState } = spawnWaiter(
+			sab,
+			AtomicState.RequestResultLength,
+		);
+
+		try {
+			waitForReady(buffer);
+			await sleep(20);
+
+			Atomics.store(buffer, NOTIFIER_INDEX, AtomicState.ResponseResultLength);
+			Atomics.notify(buffer, NOTIFIER_INDEX);
+
+			expect(await finalState).toBe(AtomicState.ResponseResultLength);
+		} finally {
+			await worker.terminate();
+		}
+	});
+
+	it("keeps waiting through the phase-1 state without corrupting it", async () => {
+		// Phase 2 of the host-call protocol waits past RequestResult (3) while
+		// the slot still holds ResponseResultLength (2) from phase 1. The waiter
+		// must neither return early nor overwrite the slot; only the host's
+		// ResponseResult (4) may release it.
+		const { sab, buffer } = makeNotifierBuffer(
+			AtomicState.ResponseResultLength,
+		);
+		const { worker, finalState } = spawnWaiter(sab, AtomicState.RequestResult);
+
+		try {
+			waitForReady(buffer);
+
+			for (let i = 0; i < 20; i++) {
+				expect(Atomics.load(buffer, NOTIFIER_INDEX)).toBe(
+					AtomicState.ResponseResultLength,
+				);
+				await sleep(2);
+			}
+
+			Atomics.store(buffer, NOTIFIER_INDEX, AtomicState.ResponseResult);
+			Atomics.notify(buffer, NOTIFIER_INDEX);
+
+			expect(await finalState).toBe(AtomicState.ResponseResult);
+		} finally {
+			await worker.terminate();
+		}
+	});
+});

--- a/libs/vm/src/worker-host-communication.ts
+++ b/libs/vm/src/worker-host-communication.ts
@@ -24,7 +24,7 @@ const MAX_I32_VALUE = 2_147_483_647;
 /** Location where the worker thread should listen for changes */
 const NOTIFIER_INDEX = 0;
 
-enum AtomicState {
+export enum AtomicState {
 	Initial = 0,
 	RequestResultLength = 1,
 	ResponseResultLength = 2,
@@ -41,20 +41,30 @@ function resetNotifierState(buffer: Int32Array) {
 	Atomics.store(buffer, NOTIFIER_INDEX, AtomicState.Initial);
 }
 
-function waitForNotifierStateChange(
+/**
+ * Blocks until the host advances the notifier state past `initialState`.
+ *
+ * Only the host writes the state while this runs: the wait loop re-reads the
+ * slot and waits on the value it observed, so a host store landing between
+ * the read and the wait makes `Atomics.wait` return "not-equal" immediately
+ * instead of being lost. Writing `initialState` into the slot here (the
+ * previous implementation) raced the host's store and could overwrite it,
+ * leaving the thread waiting forever for a notify that had already fired.
+ */
+export function waitForNotifierStateChange(
 	buffer: Int32Array,
 	initialState: AtomicState,
 ) {
-	const currentState = Atomics.load(buffer, NOTIFIER_INDEX);
+	while (true) {
+		const currentState = Atomics.load(buffer, NOTIFIER_INDEX);
 
-	// If work has already been executed don't freeze the thread and wait
-	// There is a case where the PostMessage fires and completes before a wait could be called causing a deadlock
-	if (currentState > initialState) {
-		return;
+		if (currentState > initialState) {
+			return;
+		}
+
+		// "ok" and "not-equal" both mean the state may have changed; re-check.
+		Atomics.wait(buffer, NOTIFIER_INDEX, currentState);
 	}
-
-	Atomics.store(buffer, NOTIFIER_INDEX, initialState);
-	Atomics.wait(buffer, NOTIFIER_INDEX, initialState);
 }
 
 /**


### PR DESCRIPTION
In worker mode the wasm thread parks on `Atomics.wait` while the host answers its action, and the old `waitForNotifierStateChange` did `load`, then `store(initialState)`, then `wait`. If the host's `store` + `notify` landed in the window between the load and the store, the waiter overwrote the answer state and then waited on a notify that had already fired, blocking the worker thread forever (there is no timeout on this path). The wait is now a loop that re-reads the slot and waits on the value it observed: only the host writes the state, and a store landing before the wait makes `Atomics.wait` return "not-equal" immediately instead of being lost.

This is not theoretical. A targeted repro (waiter blocking in the real function while the host delivers answers at randomized nanosecond offsets) loses 145 wakeups in 200,000 rounds (0.07%) on the old implementation under Node v25, and 0 in 400,000 on this fix. Driving a real executer workload through worker mode showed the same signature: ~1 stall per 2,800 data requests, each one wedging the worker until the host-call timeout of its caller (90s in the deployment where we first saw it).

- The new test runs the waiter on a real worker thread and asserts the notifier slot is never written while waiting; the old implementation fails it deterministically.
- No happy-path cost: bridged exec calls measure the same before and after (sub-ms, within run-to-run noise on Node and Bun).