### PR TITLE
feat: add storage capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,106 @@
+## Overview
+
+- The git base branch is `main`.
+- Use `bun` as the package manager.
+- Keep changes focused and follow established patterns in the repository.
+
+## Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## Workflow
+
+1. Inspect nearby implementation, tests, and pattern docs before editing.
+2. Prefer existing abstractions and conventions over introducing new ones.
+3. For ad hoc runnable code, create a temporary file in `scratchpad/`, run it with `bun scratchpad/<file>.ts`, and delete it when done.
+   The local runtime is Bun, which can run TypeScript files directly; use plain `bun` for local TypeScript probes.
+4. Run the validation appropriate to the change type (see below).
+5. Report which validation commands were run and any commands that could not be run.
+
+Always run `bun run fmt` before linting
+
+## Validation
+
+Use the narrowest command that still covers the change. Always run `bun run fmt` before other checks.
+
+| Change type | Command |
+|-------------|---------|
+| Formatting / style only | `bun run fmt` |
+| Unit / package tests | `bun run test` (optionally scoped to changed paths) |
+
+Typical combinations:
+
+- **Backend / shared packages:** `bun run fmt` → `bun run check-ts` → `bun test` on touched packages
+- **Admin API or frontend:** same as above; frontend uses `apps/admin-frontend` scripts where applicable
+- **Prisma:** conventions in `prisma-conventions.mdc`, then generate, migrate, and `check-migration-sql`
+
+## Changesets
+
+Create a changeset in `.changeset/` for runtime behavior changes or exported type/API changes:
+
+```md
+---
+"package-name": patch/minor/major
+---
+
+A description of the change.
+```
+
+Tests-only changes, internal refactors, docs-only changes, and JSDoc-only maintenance may skip changesets by maintainer decision.

--- a/libs/dev-tools/package.json
+++ b/libs/dev-tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/dev-tools",
 	"type": "module",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"scripts": {
 		"build:cli": "bun build src/cli/index.ts --target node --outdir bin",
 		"build": "bun run build:cli && bun run build:lib",
@@ -20,7 +20,7 @@
 		"@cosmjs/tendermint-rpc": "^0.32.4",
 		"@seda-protocol/proto-messages": "1.0.0",
 		"@seda-protocol/utils": "^1.3.0",
-		"@seda-protocol/vm": "^1.1.3",
+		"@seda-protocol/vm": "^1.2.0",
 		"big.js": "^6.2.1",
 		"dotenv": "^16.3.1",
 		"fetch-cookie": "^3.1.0",

--- a/libs/rs-sdk-integration-tests/src/main.rs
+++ b/libs/rs-sdk-integration-tests/src/main.rs
@@ -4,6 +4,7 @@ mod http;
 mod infinite_loop;
 mod proxy_http;
 mod random_get;
+mod storage;
 mod tally;
 mod vm_tests;
 
@@ -14,6 +15,11 @@ use infinite_loop::{test_infinite_loop, test_infinite_loop_http_fetch};
 use proxy_http::{test_generate_proxy_http_message, test_proxy_http_fetch};
 use random_get::test_random_get;
 use seda_sdk_rs::{bytes::ToBytes, process::Process};
+use storage::{
+    test_storage_delete, test_storage_delete_key_limit, test_storage_delete_persisted, test_storage_read,
+    test_storage_read_key_limit, test_storage_read_persisted, test_storage_write, test_storage_write_key_limit,
+    test_storage_write_value_limit,
+};
 use tally::{
     test_tally_deterministic_hashmap, test_tally_hashmap, test_tally_vm_reveals, test_tally_vm_reveals_filtered,
 };
@@ -48,6 +54,15 @@ fn main() {
         "testLongFetch" => test_long_fetch(),
         "testClockTimeGet" => test_clock_time_get(),
         "testHttpFetchAccessFile" => test_http_fetch_access_file(),
+        "testStorageWrite" => test_storage_write(),
+        "testStorageRead" => test_storage_read(),
+        "testStorageDelete" => test_storage_delete(),
+        "testStorageReadPersisted" => test_storage_read_persisted(),
+        "testStorageDeletePersisted" => test_storage_delete_persisted(),
+        "testStorageWriteValueLimit" => test_storage_write_value_limit(),
+        "testStorageWriteKeyLimit" => test_storage_write_key_limit(),
+        "testStorageReadKeyLimit" => test_storage_read_key_limit(),
+        "testStorageDeleteKeyLimit" => test_storage_delete_key_limit(),
         _ => Process::error(&"No argument given".to_bytes()),
     }
 }

--- a/libs/rs-sdk-integration-tests/src/storage.rs
+++ b/libs/rs-sdk-integration-tests/src/storage.rs
@@ -1,0 +1,141 @@
+use seda_sdk_rs::{bytes::ToBytes, process::Process, storage_delete, storage_read, storage_write};
+
+// Mirrors the limits enforced by the VM's DataRequestVmAdapter.
+const MAX_KEY_BYTES: usize = 256;
+const MAX_VALUE_BYTES: usize = 1024;
+
+pub fn test_storage_write() {
+    storage_write(&[(b"key_a", b"value_a"), (b"key_b", b"value_b")]).unwrap();
+    Process::success(&"ok".to_bytes());
+}
+
+pub fn test_storage_read() {
+    storage_write(&[(b"r1", b"alpha"), (b"r2", b"beta")]).unwrap();
+
+    let result = storage_read(&[b"r1", b"r2", b"missing"]).unwrap();
+
+    let r1_key = hex::encode(b"r1");
+    let r2_key = hex::encode(b"r2");
+    let missing_key = hex::encode(b"missing");
+
+    if result.get(&r1_key).and_then(|v| v.as_deref()) != Some(b"alpha".as_slice()) {
+        Process::error(&"r1 mismatch".to_bytes());
+    }
+
+    if result.get(&r2_key).and_then(|v| v.as_deref()) != Some(b"beta".as_slice()) {
+        Process::error(&"r2 mismatch".to_bytes());
+    }
+
+    if result.get(&missing_key) != Some(&None) {
+        Process::error(&"missing key should be present as None".to_bytes());
+    }
+
+    Process::success(&"ok".to_bytes());
+}
+
+pub fn test_storage_delete() {
+    storage_write(&[(b"d1", b"one"), (b"d2", b"two")]).unwrap();
+    storage_delete(&[b"d1"]).unwrap();
+
+    let result = storage_read(&[b"d1", b"d2"]).unwrap();
+
+    let d1_key = hex::encode(b"d1");
+    let d2_key = hex::encode(b"d2");
+
+    if result.get(&d1_key) != Some(&None) {
+        Process::error(&"d1 should be None after delete".to_bytes());
+    }
+    if result.get(&d2_key).and_then(|v| v.as_deref()) != Some(b"two".as_slice()) {
+        Process::error(&"d2 should still exist".to_bytes());
+    }
+
+    Process::success(&"ok".to_bytes());
+}
+
+// Reads the keys written by `test_storage_write` without writing them first
+pub fn test_storage_read_persisted() {
+    let result = storage_read(&[b"key_a", b"key_b"]).unwrap();
+
+    let key_a = hex::encode(b"key_a");
+    let key_b = hex::encode(b"key_b");
+
+    if result.get(&key_a).and_then(|v| v.as_deref()) != Some(b"value_a".as_slice()) {
+        Process::error(&"key_a not persisted".to_bytes());
+    }
+
+    if result.get(&key_b).and_then(|v| v.as_deref()) != Some(b"value_b".as_slice()) {
+        Process::error(&"key_b not persisted".to_bytes());
+    }
+
+    Process::success(&"ok".to_bytes());
+}
+
+// Deletes a key that was persisted by a previous execution without writing it first.
+pub fn test_storage_delete_persisted() {
+    storage_delete(&[b"key_a"]).unwrap();
+    Process::success(&"ok".to_bytes());
+}
+
+pub fn test_storage_write_value_limit() {
+    // A value exactly at the limit is accepted.
+    let at_limit_value = vec![b'a'; MAX_VALUE_BYTES];
+    if storage_write(&[(b"v_at_limit".as_slice(), at_limit_value.as_slice())]).is_err() {
+        Process::error(&"value at the limit should be accepted".to_bytes());
+    }
+
+    // A value over the limit is rejected.
+    let over_limit_value = vec![b'a'; MAX_VALUE_BYTES + 1];
+    if storage_write(&[(b"v_over_limit".as_slice(), over_limit_value.as_slice())]).is_ok() {
+        Process::error(&"value over the limit should be rejected".to_bytes());
+    }
+
+    Process::success(&"ok".to_bytes());
+}
+
+pub fn test_storage_write_key_limit() {
+    // A key exactly at the limit is accepted.
+    let at_limit_key = vec![b'k'; MAX_KEY_BYTES];
+    if storage_write(&[(at_limit_key.as_slice(), b"value".as_slice())]).is_err() {
+        Process::error(&"key at the limit should be accepted".to_bytes());
+    }
+
+    // A key over the limit is rejected.
+    let over_limit_key = vec![b'k'; MAX_KEY_BYTES + 1];
+    if storage_write(&[(over_limit_key.as_slice(), b"value".as_slice())]).is_ok() {
+        Process::error(&"key over the limit should be rejected".to_bytes());
+    }
+
+    Process::success(&"ok".to_bytes());
+}
+
+pub fn test_storage_read_key_limit() {
+    // A key exactly at the limit is accepted.
+    let at_limit_key = vec![b'k'; MAX_KEY_BYTES];
+    if storage_read(&[at_limit_key.as_slice()]).is_err() {
+        Process::error(&"read with a key at the limit should be allowed".to_bytes());
+    }
+
+    // A key over the limit is rejected.
+    let over_limit_key = vec![b'k'; MAX_KEY_BYTES + 1];
+    if storage_read(&[over_limit_key.as_slice()]).is_ok() {
+        Process::error(&"read with an over-limit key should be rejected".to_bytes());
+    }
+
+    Process::success(&"ok".to_bytes());
+}
+
+pub fn test_storage_delete_key_limit() {
+    // A key exactly at the limit is accepted.
+    let at_limit_key = vec![b'k'; MAX_KEY_BYTES];
+    if storage_delete(&[at_limit_key.as_slice()]).is_err() {
+        Process::error(&"delete with a key at the limit should be allowed".to_bytes());
+    }
+
+    // A key over the limit is rejected.
+    let over_limit_key = vec![b'k'; MAX_KEY_BYTES + 1];
+    if storage_delete(&[over_limit_key.as_slice()]).is_ok() {
+        Process::error(&"delete with an over-limit key should be rejected".to_bytes());
+    }
+
+    Process::success(&"ok".to_bytes());
+}

--- a/libs/rs-sdk/sdk/src/errors.rs
+++ b/libs/rs-sdk/sdk/src/errors.rs
@@ -28,6 +28,10 @@ pub enum SDKError {
     #[error("Invalid value")]
     InvalidValue,
 
+    /// A host promise was rejected, e.g. a storage key or value exceeded the configured size limit.
+    #[error("Promise rejected: {0}")]
+    PromiseRejected(String),
+
     /// The x-seda-signature header in a proxy http response is missing.
     #[error("Missing x-seda-signature header")]
     MissingSignatureHeader,

--- a/libs/rs-sdk/sdk/src/lib.rs
+++ b/libs/rs-sdk/sdk/src/lib.rs
@@ -12,6 +12,7 @@ pub mod promise;
 pub mod proxy_http_fetch;
 mod raw;
 pub mod secp256k1;
+pub mod storage;
 mod tally;
 mod vm_modes;
 
@@ -20,6 +21,7 @@ pub use keccak256::keccak256;
 pub use process::Process;
 pub use proxy_http_fetch::{generate_proxy_http_signing_message, proxy_http_fetch};
 pub use secp256k1::secp256k1_verify;
+pub use storage::{storage_delete, storage_read, storage_write};
 pub use tally::*;
 
 pub use seda_sdk_macros::oracle_program;

--- a/libs/rs-sdk/sdk/src/promise.rs
+++ b/libs/rs-sdk/sdk/src/promise.rs
@@ -45,7 +45,7 @@ impl PromiseStatus {
             return value;
         }
 
-        panic!("Promise is not fulfilled: {:?}", &self);
+        panic!("Promise is not fulfilled: {:?}", self);
     }
 
     /// Parses the fulfilled value of the promise into the desired type.

--- a/libs/rs-sdk/sdk/src/raw.rs
+++ b/libs/rs-sdk/sdk/src/raw.rs
@@ -8,6 +8,11 @@ extern "C" {
     pub fn http_fetch(action: *const u8, action_length: u32) -> u32;
     pub fn proxy_http_fetch(action: *const u8, action_length: u32) -> u32;
 
+    // Storage actions
+    pub fn storage_read(action: *const u8, action_length: u32) -> u32;
+    pub fn storage_write(action: *const u8, action_length: u32) -> u32;
+    pub fn storage_delete(action: *const u8, action_length: u32) -> u32;
+
     // Reading call actions result
     pub fn call_result_write(result: *const u8, result_length: u32);
     pub fn keccak256(message: *const u8, message_length: u32) -> u32;

--- a/libs/rs-sdk/sdk/src/storage.rs
+++ b/libs/rs-sdk/sdk/src/storage.rs
@@ -1,0 +1,100 @@
+//! Storage operations for persisting data across oracle program executions.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use crate::{
+    errors::{Result, SDKError},
+    promise::PromiseStatus,
+};
+
+#[derive(Serialize)]
+struct StorageReadAction {
+    keys: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct StorageWriteAction {
+    values: BTreeMap<String, String>,
+}
+
+#[derive(Serialize)]
+struct StorageDeleteAction {
+    keys: Vec<String>,
+}
+
+/// Writes multiple key-value pairs to storage.
+///
+/// # Errors
+///
+/// Returns an error if the host rejected the write, for example when a key or
+/// value exceeds the configured size limit.
+pub fn storage_write(entries: &[(&[u8], &[u8])]) -> Result<()> {
+    let values: BTreeMap<String, String> = entries.iter().map(|(k, v)| (hex::encode(k), hex::encode(v))).collect();
+
+    let action = StorageWriteAction { values };
+    let action_json = serde_json::to_string(&action)?;
+
+    let result_length = unsafe { super::raw::storage_write(action_json.as_ptr(), action_json.len() as u32) };
+    let mut result_data = vec![0u8; result_length as usize];
+    unsafe {
+        super::raw::call_result_write(result_data.as_mut_ptr(), result_length);
+    }
+
+    match serde_json::from_slice(&result_data)? {
+        PromiseStatus::Fulfilled(_) => Ok(()),
+        PromiseStatus::Rejected(error) => Err(SDKError::PromiseRejected(String::from_utf8(error)?)),
+    }
+}
+
+/// Reads multiple keys from storage. Returns a map containing every
+/// requested key — the value is `Some(bytes)` if the key exists,
+/// or `None` if it does not.
+///
+/// # Errors
+///
+/// Returns an error if the host rejected the read, for example when a key
+/// exceeds the configured size limit.
+pub fn storage_read(keys: &[&[u8]]) -> Result<BTreeMap<String, Option<Vec<u8>>>> {
+    let action = StorageReadAction {
+        keys: keys.iter().map(hex::encode).collect(),
+    };
+    let action_json = serde_json::to_string(&action)?;
+
+    let result_length = unsafe { super::raw::storage_read(action_json.as_ptr(), action_json.len() as u32) };
+    let mut result_data = vec![0u8; result_length as usize];
+    unsafe {
+        super::raw::call_result_write(result_data.as_mut_ptr(), result_length);
+    }
+
+    match serde_json::from_slice(&result_data)? {
+        PromiseStatus::Fulfilled(Some(bytes)) if !bytes.is_empty() => Ok(serde_json::from_slice(&bytes)?),
+        PromiseStatus::Fulfilled(_) => Ok(BTreeMap::new()),
+        PromiseStatus::Rejected(error) => Err(SDKError::PromiseRejected(String::from_utf8(error)?)),
+    }
+}
+
+/// Deletes multiple keys from storage.
+///
+/// # Errors
+///
+/// Returns an error if the host rejected the delete, for example when a key
+/// exceeds the configured size limit.
+pub fn storage_delete(keys: &[&[u8]]) -> Result<()> {
+    let action = StorageDeleteAction {
+        keys: keys.iter().map(hex::encode).collect(),
+    };
+    let action_json = serde_json::to_string(&action)?;
+
+    let result_length = unsafe { super::raw::storage_delete(action_json.as_ptr(), action_json.len() as u32) };
+    let mut result_data = vec![0u8; result_length as usize];
+    unsafe {
+        super::raw::call_result_write(result_data.as_mut_ptr(), result_length);
+    }
+
+    match serde_json::from_slice(&result_data)? {
+        PromiseStatus::Fulfilled(_) => Ok(()),
+        PromiseStatus::Rejected(error) => Err(SDKError::PromiseRejected(String::from_utf8(error)?)),
+    }
+}

--- a/libs/vm/package.json
+++ b/libs/vm/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@seda-protocol/vm",
 	"type": "module",
-	"version": "1.1.3",
+	"version": "1.2.0",
 	"dependencies": {
 		"@seda-protocol/wasm-metering-ts": "^2.0.1",
 		"uwasi": "^1.4.1",

--- a/libs/vm/src/data-request-vm-adapter.ts
+++ b/libs/vm/src/data-request-vm-adapter.ts
@@ -7,6 +7,10 @@ import { readStream } from "./services/read-stream.js";
 import type {
 	HttpFetchAction,
 	ProxyHttpFetchAction,
+	StorageDeleteAction,
+	StorageReadAction,
+	StorageReadResponse,
+	StorageWriteAction,
 } from "./types/vm-actions.js";
 import { HttpFetchResponse } from "./types/vm-actions.js";
 import type { VmAdapter } from "./types/vm-adapter.js";
@@ -19,6 +23,9 @@ interface Options {
 	mockProxyGasCost?: bigint;
 	maxResponseBytes?: number;
 	totalHttpTimeLimit?: number;
+
+	maxStorageKeyBytes?: number;
+	maxStorageValueBytes?: number;
 
 	/**
 	 * The clock time to use for the VM.
@@ -34,6 +41,8 @@ export default class DataRequestVmAdapter implements VmAdapter {
 	private maxResponseBytes = 10 * 1024 * 1024; // 10MB
 	private totalHttpTimeLimit = 20_000;
 	private totalHttpTimeLeft = 20_000;
+	private maxStorageKeyBytes = 256;
+	private maxStorageValueBytes = 1024;
 
 	constructor(private opts?: Options) {
 		if (opts?.fetchMock) {
@@ -62,6 +71,14 @@ export default class DataRequestVmAdapter implements VmAdapter {
 		if (opts?.totalHttpTimeLimit) {
 			this.totalHttpTimeLimit = opts.totalHttpTimeLimit;
 			this.totalHttpTimeLeft = opts.totalHttpTimeLimit;
+		}
+
+		if (opts?.maxStorageKeyBytes) {
+			this.maxStorageKeyBytes = opts.maxStorageKeyBytes;
+		}
+
+		if (opts?.maxStorageValueBytes) {
+			this.maxStorageValueBytes = opts.maxStorageValueBytes;
 		}
 	}
 
@@ -228,6 +245,83 @@ export default class DataRequestVmAdapter implements VmAdapter {
 
 		// Default to realtime if no mode is provided
 		return Date.now();
+	}
+
+	async _storageRead(
+		action: StorageReadAction,
+	): Promise<PromiseStatus<StorageReadResponse>> {
+		for (const key of action.keys) {
+			const keyBytes = Buffer.from(key, "hex");
+
+			if (keyBytes.length > this.maxStorageKeyBytes) {
+				return PromiseStatus.rejected(
+					new VmError(
+						`Storage key is too long (got ${keyBytes.length} bytes, max ${this.maxStorageKeyBytes}): ${key}`,
+					),
+				);
+			}
+		}
+
+		return this.storageRead(action);
+	}
+
+	async storageRead(
+		action: StorageReadAction,
+	): Promise<PromiseStatus<StorageReadResponse>> {
+		throw new VmError("Unimplemented");
+	}
+
+	async _storageWrite(
+		action: StorageWriteAction,
+	): Promise<PromiseStatus<void>> {
+		for (const key of Object.keys(action.values)) {
+			const keyBytes = Buffer.from(key, "hex");
+			if (keyBytes.length > this.maxStorageKeyBytes) {
+				return PromiseStatus.rejected(
+					new VmError(
+						`Storage key is too long (got ${keyBytes.length} bytes, max ${this.maxStorageKeyBytes}): ${key}`,
+					),
+				);
+			}
+
+			const valueBytes = Buffer.from(action.values[key], "hex");
+			if (valueBytes.length > this.maxStorageValueBytes) {
+				return PromiseStatus.rejected(
+					new VmError(
+						`Storage value is too long (got ${valueBytes.length} bytes, max ${this.maxStorageValueBytes}): ${action.values[key]}`,
+					),
+				);
+			}
+		}
+
+		return this.storageWrite(action);
+	}
+
+	async storageWrite(action: StorageWriteAction): Promise<PromiseStatus<void>> {
+		throw new VmError("Unimplemented");
+	}
+
+	async _storageDelete(
+		action: StorageDeleteAction,
+	): Promise<PromiseStatus<void>> {
+		for (const key of action.keys) {
+			const keyBytes = Buffer.from(key, "hex");
+			if (keyBytes.length > this.maxStorageKeyBytes) {
+				return PromiseStatus.rejected(
+					new VmError(
+						`Storage key is too long (got ${keyBytes.length} bytes, max ${this.maxStorageKeyBytes}): ${key}`,
+					),
+				);
+			}
+		}
+
+		return this.storageDelete(action);
+	}
+
+	async storageDelete(
+		action: StorageDeleteAction,
+	): Promise<PromiseStatus<void>> {
+		throw new VmError("Unimplemented");
 	}
 }
 

--- a/libs/vm/src/errors.ts
+++ b/libs/vm/src/errors.ts
@@ -1,3 +1,5 @@
+import type { ToBuffer } from "./types/vm-promise.js";
+
 export enum VmErrorType {
 	OutOfGas = "OutOfGas",
 	HttpFetchTimeout = "HttpFetchTimeout",
@@ -10,7 +12,7 @@ interface VmErrorOptions extends ErrorOptions {
 	type: VmErrorType;
 }
 
-export class VmError extends Error {
+export class VmError extends Error implements ToBuffer {
 	public type: VmErrorType;
 
 	constructor(message?: string, options?: VmErrorOptions) {
@@ -18,5 +20,9 @@ export class VmError extends Error {
 		super(`VmError(${message})`, options);
 
 		this.type = options?.type ?? VmErrorType.Unknown;
+	}
+
+	toBuffer(): Uint8Array {
+		return new TextEncoder().encode(this.message);
 	}
 }

--- a/libs/vm/src/index.ts
+++ b/libs/vm/src/index.ts
@@ -39,6 +39,10 @@ export {
 	type ProxyHttpFetchAction,
 	type ProxyHttpFetchGasCostAction,
 	type HttpFetchResponseData,
+	type StorageDeleteAction,
+	type StorageReadAction,
+	type StorageReadResponse,
+	type StorageWriteAction,
 } from "./types/vm-actions.js";
 
 /**

--- a/libs/vm/src/metering.ts
+++ b/libs/vm/src/metering.ts
@@ -21,6 +21,11 @@ const GAS_PER_BYTE_EXECUTION_RESULT = 10_000_000n;
 
 const TERA_GAS = 1_000_000_000_000n;
 
+// Storage Gas
+const GAS_STORAGE_READ_BASE = TERA_GAS;
+const GAS_STORAGE_WRITE_BASE = TERA_GAS * 2n;
+const GAS_STORAGE_DELETE_BASE = TERA_GAS * 2n;
+
 // Makes it so you can do roughly 30 http requests with the current gas calculations.
 const GAS_HTTP_FETCH_BASE = TERA_GAS * 5n;
 
@@ -56,6 +61,10 @@ export enum CallType {
 	FdWrite = 12,
 	RandomGet = 13,
 	ClockTimeGet = 14,
+	StorageRead = 15,
+	StorageReadResponse = 16,
+	StorageWrite = 17,
+	StorageDelete = 18,
 }
 
 export const OUT_OF_GAS_MESSAGE = "Ran out of gas";
@@ -238,6 +247,18 @@ export class GasMeter {
 				break;
 			case CallType.ClockTimeGet:
 				gasCost = GAS_CLOCK_TIME_GET_BASE;
+				break;
+			case CallType.StorageRead:
+				gasCost = GAS_STORAGE_READ_BASE + GAS_PER_BYTE * bytesLength;
+				break;
+			case CallType.StorageReadResponse:
+				gasCost = GAS_PER_BYTE * bytesLength;
+				break;
+			case CallType.StorageWrite:
+				gasCost = GAS_STORAGE_WRITE_BASE + GAS_PER_BYTE * bytesLength;
+				break;
+			case CallType.StorageDelete:
+				gasCost = GAS_STORAGE_DELETE_BASE + GAS_PER_BYTE * bytesLength;
 				break;
 			default:
 				throw new VmError("Unknown call type");

--- a/libs/vm/src/tally-vm-adapter.ts
+++ b/libs/vm/src/tally-vm-adapter.ts
@@ -1,7 +1,12 @@
 import { Result } from "true-myth";
+import { VmError } from "./errors.js";
 import type {
 	HttpFetchAction,
 	ProxyHttpFetchAction,
+	StorageDeleteAction,
+	StorageReadAction,
+	StorageReadResponse,
+	StorageWriteAction,
 } from "./types/vm-actions.js";
 import { HttpFetchResponse } from "./types/vm-actions.js";
 import type { VmAdapter } from "./types/vm-adapter.js";
@@ -84,5 +89,39 @@ export default class TallyVmAdapter implements VmAdapter {
 
 		// Default to realtime if no mode is provided
 		return Date.now();
+	}
+
+	async _storageRead(
+		action: StorageReadAction,
+	): Promise<PromiseStatus<StorageReadResponse>> {
+		return this.storageRead(action);
+	}
+
+	async storageRead(
+		action: StorageReadAction,
+	): Promise<PromiseStatus<StorageReadResponse>> {
+		throw new VmError("unimplemented");
+	}
+
+	async _storageWrite(
+		action: StorageWriteAction,
+	): Promise<PromiseStatus<void>> {
+		return this.storageWrite(action);
+	}
+
+	async storageWrite(action: StorageWriteAction): Promise<PromiseStatus<void>> {
+		throw new VmError("unimplemented");
+	}
+
+	async _storageDelete(
+		action: StorageDeleteAction,
+	): Promise<PromiseStatus<void>> {
+		return this.storageDelete(action);
+	}
+
+	async storageDelete(
+		action: StorageDeleteAction,
+	): Promise<PromiseStatus<void>> {
+		throw new VmError("unimplemented");
 	}
 }

--- a/libs/vm/src/types/vm-actions.ts
+++ b/libs/vm/src/types/vm-actions.ts
@@ -26,7 +26,29 @@ export interface HttpFetchOptions {
 export type VmAction =
 	| HttpFetchAction
 	| ProxyHttpFetchAction
-	| ProxyHttpFetchGasCostAction;
+	| ProxyHttpFetchGasCostAction
+	| StorageReadAction
+	| StorageWriteAction
+	| StorageDeleteAction;
+
+export interface StorageReadAction {
+	keys: string[];
+	type: "storage-read-action";
+}
+
+export interface StorageReadResponse {
+	[key: string]: Buffer;
+}
+
+export interface StorageWriteAction {
+	values: { [key: string]: string };
+	type: "storage-write-action";
+}
+
+export interface StorageDeleteAction {
+	keys: string[];
+	type: "storage-delete-action";
+}
 
 export interface HttpFetchAction {
 	url: string;

--- a/libs/vm/src/types/vm-adapter.ts
+++ b/libs/vm/src/types/vm-adapter.ts
@@ -4,6 +4,10 @@ import type {
 	HttpFetchAction,
 	HttpFetchResponse,
 	ProxyHttpFetchAction,
+	StorageDeleteAction,
+	StorageReadAction,
+	StorageReadResponse,
+	StorageWriteAction,
 } from "./vm-actions";
 import type { VmCallData } from "./vm-call-data.js";
 import type { PromiseStatus } from "./vm-promise.js";
@@ -60,4 +64,38 @@ export interface VmAdapter {
 	 * @returns the current clock time in milliseconds
 	 */
 	getClockTime(mode: "monotonic" | "realtime"): number;
+
+	/**
+	 * Method to read the storage (with key validation)
+	 */
+	_storageRead(
+		action: StorageReadAction,
+	): Promise<PromiseStatus<StorageReadResponse>>;
+
+	/**
+	 * Method to read the storage
+	 */
+	storageRead(
+		action: StorageReadAction,
+	): Promise<PromiseStatus<StorageReadResponse>>;
+
+	/**
+	 * Method to write the storage (with key validation)
+	 */
+	_storageWrite(action: StorageWriteAction): Promise<PromiseStatus<void>>;
+
+	/**
+	 * Method to write the storage
+	 */
+	storageWrite(action: StorageWriteAction): Promise<PromiseStatus<void>>;
+
+	/**
+	 * Method to delete the storage (with key validation)
+	 */
+	_storageDelete(action: StorageDeleteAction): Promise<PromiseStatus<void>>;
+
+	/**
+	 * Method to delete the storage
+	 */
+	storageDelete(action: StorageDeleteAction): Promise<PromiseStatus<void>>;
 }

--- a/libs/vm/src/types/vm-call-data.ts
+++ b/libs/vm/src/types/vm-call-data.ts
@@ -15,6 +15,8 @@ export interface VmCallData {
 	cache?: CacheOptions;
 	stdoutLimit?: number;
 	stderrLimit?: number;
+	maxStorageKeyBytes?: number;
+	maxStorageValueBytes?: number;
 	wasmModuleCache?: WasmModuleCache;
 }
 

--- a/libs/vm/src/vm-imports.ts
+++ b/libs/vm/src/vm-imports.ts
@@ -16,6 +16,9 @@ import {
 	HttpFetchResponse,
 	type ProxyHttpFetchAction,
 	type ProxyHttpFetchGasCostAction,
+	type StorageDeleteAction,
+	type StorageReadAction,
+	type StorageWriteAction,
 } from "./types/vm-actions.js";
 import type { VmAdapter } from "./types/vm-adapter.js";
 import type { VmCallData } from "./types/vm-call-data.js";
@@ -199,6 +202,110 @@ export default class VmImports {
 			console.error(`[${this.processId}] - @httpFetch: ${messageRaw}`, error);
 			this.callResult = new Uint8Array();
 
+			return 0;
+		}
+	}
+
+	storageRead(actionPtr: number, actionLength: number) {
+		this.gasMeter.applyGasCost(CallType.StorageRead, BigInt(actionLength));
+
+		const actionRaw = Buffer.from(
+			new Uint8Array(
+				this.memory?.buffer.slice(actionPtr, actionPtr + actionLength) ?? [],
+			),
+		);
+
+		const action: StorageReadAction = {
+			...JSON.parse(actionRaw.toString("utf-8")),
+			type: "storage-read-action",
+		};
+
+		try {
+			this.callResult = this.workerToHost.callActionOnHost(action);
+
+			this.gasMeter.applyGasCost(
+				CallType.StorageReadResponse,
+				BigInt(this.callResult.length),
+			);
+			return this.callResult.length;
+		} catch (error) {
+			if (error instanceof VmActionRequest) {
+				this.reExecutionRequest = error;
+				throw error;
+			}
+
+			if (error instanceof VmError && error.type === VmErrorType.OutOfGas) {
+				throw error;
+			}
+
+			console.error(`[${this.processId}] - @storageRead`, error);
+			this.callResult = new Uint8Array();
+			return 0;
+		}
+	}
+
+	storageWrite(actionPtr: number, actionLength: number) {
+		this.gasMeter.applyGasCost(CallType.StorageWrite, BigInt(actionLength));
+
+		const actionRaw = Buffer.from(
+			new Uint8Array(
+				this.memory?.buffer.slice(actionPtr, actionPtr + actionLength) ?? [],
+			),
+		);
+
+		const action: StorageWriteAction = {
+			...JSON.parse(actionRaw.toString("utf-8")),
+			type: "storage-write-action",
+		};
+
+		try {
+			this.callResult = this.workerToHost.callActionOnHost(action);
+			return this.callResult.length;
+		} catch (error) {
+			if (error instanceof VmActionRequest) {
+				this.reExecutionRequest = error;
+				throw error;
+			}
+
+			if (error instanceof VmError && error.type === VmErrorType.OutOfGas) {
+				throw error;
+			}
+
+			console.error(`[${this.processId}] - @storageWrite`, error);
+			this.callResult = new Uint8Array();
+			return 0;
+		}
+	}
+
+	storageDelete(actionPtr: number, actionLength: number) {
+		this.gasMeter.applyGasCost(CallType.StorageDelete, BigInt(actionLength));
+
+		const actionRaw = Buffer.from(
+			new Uint8Array(
+				this.memory?.buffer.slice(actionPtr, actionPtr + actionLength) ?? [],
+			),
+		);
+
+		const action: StorageDeleteAction = {
+			...JSON.parse(actionRaw.toString("utf-8")),
+			type: "storage-delete-action",
+		};
+
+		try {
+			this.callResult = this.workerToHost.callActionOnHost(action);
+			return this.callResult.length;
+		} catch (error) {
+			if (error instanceof VmActionRequest) {
+				this.reExecutionRequest = error;
+				throw error;
+			}
+
+			if (error instanceof VmError && error.type === VmErrorType.OutOfGas) {
+				throw error;
+			}
+
+			console.error(`[${this.processId}] - @storageDelete`, error);
+			this.callResult = new Uint8Array();
 			return 0;
 		}
 	}
@@ -393,6 +500,9 @@ export default class VmImports {
 				keccak256: this.keccak256.bind(this),
 				call_result_write: this.callResultWrite.bind(this),
 				execution_result: this.executionResult.bind(this),
+				storage_read: this.storageRead.bind(this),
+				storage_write: this.storageWrite.bind(this),
+				storage_delete: this.storageDelete.bind(this),
 			},
 		};
 	}

--- a/libs/vm/src/vm.ts
+++ b/libs/vm/src/vm.ts
@@ -9,7 +9,6 @@ import {
 import { HttpFetchResponse } from "./types/vm-actions.js";
 import type { VmAdapter } from "./types/vm-adapter.js";
 import type { VmCallData } from "./types/vm-call-data.js";
-import { PromiseStatus } from "./types/vm-promise.js";
 import VmImports from "./vm-imports.js";
 import { HostToWorker, VmActionRequest } from "./worker-host-communication.js";
 

--- a/libs/vm/src/worker-host-communication.ts
+++ b/libs/vm/src/worker-host-communication.ts
@@ -100,6 +100,30 @@ export class HostToWorker {
 				Err: (error) =>
 					HttpFetchResponse.createRejectedPromise(error.message).toBuffer(),
 			});
+		} else if (action.type === "storage-read-action") {
+			const actionResult = await tryAsync(this.adapter._storageRead(action));
+
+			this.actionResult = actionResult.match({
+				Ok: (value) => value.toBuffer(),
+				Err: (error) =>
+					HttpFetchResponse.createRejectedPromise(error.message).toBuffer(),
+			});
+		} else if (action.type === "storage-write-action") {
+			const actionResult = await tryAsync(this.adapter._storageWrite(action));
+
+			this.actionResult = actionResult.match({
+				Ok: (value) => value.toBuffer(),
+				Err: (error) =>
+					HttpFetchResponse.createRejectedPromise(error.message).toBuffer(),
+			});
+		} else if (action.type === "storage-delete-action") {
+			const actionResult = await tryAsync(this.adapter._storageDelete(action));
+
+			this.actionResult = actionResult.match({
+				Ok: (value) => value.toBuffer(),
+				Err: (error) =>
+					HttpFetchResponse.createRejectedPromise(error.message).toBuffer(),
+			});
 		}
 
 		if (typeof this.actionResult === "undefined") {

--- a/libs/wasm-integration-tests/tests/rs-sdk/storage.test.ts
+++ b/libs/wasm-integration-tests/tests/rs-sdk/storage.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test";
+import {
+	DataRequestVmAdapter,
+	PromiseStatus,
+	type StorageDeleteAction,
+	type StorageReadAction,
+	type StorageReadResponse,
+	type StorageWriteAction,
+	callVm,
+} from "@seda-protocol/vm";
+import { oracleProgram } from "./oracle-program";
+
+class StorageReadResult {
+	constructor(private data: Record<string, number[] | null>) {}
+	toBuffer(): Uint8Array {
+		return new TextEncoder().encode(JSON.stringify(this.data));
+	}
+}
+
+class MockStorageAdapter extends DataRequestVmAdapter {
+	storage = new Map<string, Buffer>();
+
+	async storageWrite(action: StorageWriteAction): Promise<PromiseStatus<void>> {
+		for (const [key, value] of Object.entries(action.values)) {
+			this.storage.set(key, Buffer.from(value, "hex"));
+		}
+		return PromiseStatus.fulfilled();
+	}
+
+	async storageRead(
+		action: StorageReadAction,
+	): Promise<PromiseStatus<StorageReadResponse>> {
+		const result: Record<string, number[] | null> = {};
+		for (const key of action.keys) {
+			const value = this.storage.get(key);
+			result[key] = value ? Array.from(value) : null;
+		}
+		return PromiseStatus.fulfilled(new StorageReadResult(result));
+	}
+
+	async storageDelete(
+		action: StorageDeleteAction,
+	): Promise<PromiseStatus<void>> {
+		for (const key of action.keys) {
+			this.storage.delete(key);
+		}
+		return PromiseStatus.fulfilled();
+	}
+}
+
+function executeWithMockStorage(
+	testName: string,
+	adapter: MockStorageAdapter = new MockStorageAdapter(),
+) {
+	return callVm(
+		{
+			args: [Buffer.from(testName).toString("hex")],
+			envs: { CHAIN_ID: "seda-1-local" },
+			binary: new Uint8Array(oracleProgram),
+			vmMode: "exec",
+		},
+		undefined,
+		adapter,
+		true,
+	);
+}
+
+describe("rs-sdk:storage", () => {
+	it("should write to storage", async () => {
+		const result = await executeWithMockStorage("testStorageWrite");
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("ok");
+	});
+
+	it("should read from storage", async () => {
+		const result = await executeWithMockStorage("testStorageRead");
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("ok");
+	});
+
+	it("should delete from storage", async () => {
+		const result = await executeWithMockStorage("testStorageDelete");
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("ok");
+	});
+
+	it("should read values persisted by a previous execution", async () => {
+		const adapter = new MockStorageAdapter();
+
+		const write = await executeWithMockStorage("testStorageWrite", adapter);
+		expect(write.exitCode).toBe(0);
+
+		const result = await executeWithMockStorage(
+			"testStorageReadPersisted",
+			adapter,
+		);
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("ok");
+	});
+
+	it("should delete a key persisted by a previous execution", async () => {
+		const adapter = new MockStorageAdapter();
+
+		const write = await executeWithMockStorage("testStorageWrite", adapter);
+		expect(write.exitCode).toBe(0);
+
+		const result = await executeWithMockStorage(
+			"testStorageDeletePersisted",
+			adapter,
+		);
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("ok");
+
+		const keyA = Buffer.from("key_a").toString("hex");
+		const keyB = Buffer.from("key_b").toString("hex");
+		expect(adapter.storage.has(keyA)).toBe(false);
+		expect(adapter.storage.has(keyB)).toBe(true);
+	});
+
+	it("should enforce the storage value size limit on write", async () => {
+		const result = await executeWithMockStorage("testStorageWriteValueLimit");
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("ok");
+	});
+
+	it("should enforce the storage key size limit on write", async () => {
+		const result = await executeWithMockStorage("testStorageWriteKeyLimit");
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("ok");
+	});
+
+	it("should enforce the storage key size limit on read", async () => {
+		const result = await executeWithMockStorage("testStorageReadKeyLimit");
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("ok");
+	});
+
+	it("should enforce the storage key size limit on delete", async () => {
+		const result = await executeWithMockStorage("testStorageDeleteKeyLimit");
+		expect(result.exitCode).toBe(0);
+		expect(result.resultAsString).toBe("ok");
+	});
+});


### PR DESCRIPTION
## Motivation

Add key value storage for Oracle Programs

## Explanation of Changes

- three new imports `storage_read`, `storage_write`, and `storage_delete`
- Adds check for storage sizes to make sure no limits are exceeded
- Adds gas metering for storage reading, writing and deleting (treats delete the same as a write since it needs to still write to the database)

## Testing

```
bun run test
```